### PR TITLE
Fix minor typo for action node

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
   github token:
     description: 'GITHUB_TOKEN to be able to perform requests to GH REST API (with no limit)'
   driver:
-    desrciption: 'Minikube driver to use. This action supports `none` (default if not specified) or `docker`'
+    description: 'Minikube driver to use. This action supports `none` (default if not specified) or `docker`'
   start args:
-    desrciption: 'Additional arguments to append to minikube start command'
+    description: 'Additional arguments to append to minikube start command'
 runs:
   using: 'node12'
   main: 'src/index.js'


### PR DESCRIPTION
The node 'desrciption' is renamed to 'description'.
This fixes the issue [0].

[0] https://github.com/manusa/actions-setup-minikube/issues/37

Fix: desrciption typo