### PR TITLE
fix: use HOME environment variable instead of hardcoding /home/runner

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -28,7 +28,7 @@ const install = async (minikube, inputs) => {
   );
   logExecSync(`sudo chown -R $USER $HOME/.kube ${minikubeDirectory}/.minikube`);
   logExecSync(
-    `sudo chmod -R a+r /home/runner/.kube ${minikubeDirectory}/.minikube`
+    `sudo chmod -R a+r $HOME/.kube ${minikubeDirectory}/.minikube`
   );
   logExecSync(
     `sudo find ${minikubeDirectory}/.minikube -name id_rsa -exec chmod 600 {} \\;`


### PR DESCRIPTION
If you run actions-setup-minikube on a machine that has a different `HOME` directory (like an external Github Actions runner like https://github.com/machulav/ec2-github-runner), you get the following error:

```
chmod: cannot access '/home/runner/.kube': No such file or directory
Error: Command failed: sudo chmod -R a+r /home/runner/.kube /actions-runner/_work/_temp/.minikube
    at checkExecSyncError (child_process.js:621:11)
    at Object.execSync (child_process.js:657:15)
    at logExecSync (/actions-runner/_work/_actions/manusa/actions-setup-minikube/v2.4.1/src/exec.js:8:17)
    at install (/actions-runner/_work/_actions/manusa/actions-setup-minikube/v2.4.1/src/install.js:30:3)
    at async run (/actions-runner/_work/_actions/manusa/actions-setup-minikube/v2.4.1/src/index.js:16:3) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 5910,
  stdout: null,
  stderr: null
}
Error: Command failed: sudo chmod -R a+r /home/runner/.kube /actions-runner/_work/_temp/.minikube
Error: Command failed: sudo chmod -R a+r /home/runner/.kube /actions-runner/_work/_temp/.minikube
```

I think this is the only case where `/home/runner` is hardcoded instead of using `$HOME`.