### PR TITLE
ci: Verify Ingress addon works on E2E tests

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.16.0
-          kubernetes version: v1.19.2
+          minikube version: v1.21.0
+          kubernetes version: v1.21.0
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=registry --addons=metrics-server'
       - name: Validate Minikube
@@ -74,6 +74,27 @@ jobs:
         run: kubectl get nodes
       - name: Validate enabled addon in arg
         run: minikube addons list -o json | jq '.registry.Status' | grep enabled
+  ingress:
+    name: Run with ingress enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@master
+      - name: Test Action
+        uses: ./
+        with:
+          minikube version: v1.21.0
+          kubernetes version: v1.21.0
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          start args: '--addons=ingress'
+      - name: Validate Minikube
+        run: minikube status | grep Running
+      - name: Validate Cluster
+        run: kubectl get nodes
+      - name: Validate enabled addon in arg
+        run: minikube addons list -o json | jq '.ingress.Status' | grep enabled
   legacy:
     name: Run for legacy/old versions
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Description

Ingress addon was reported to be failing again:

```
* This can also be done automatically by setting the env var CHANGE_MINIKUBE_NONE_USER=true
* Verifying Kubernetes components...

X Exiting due to MK_USAGE: Due to networking limitations of driver none, ingress addon is not supported. Try using a different driver.
Error: Command failed: sudo -E /home/runner/work/_temp/minikube start --vm-driver=none --kubernetes-version v1.19.2 --force --addons=ingress
```

Relates to: #14 #15