### PR TITLE
Upgrade cri-dockerd version to fix a bug that can not download large images

### DIFF
--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -171,11 +171,11 @@ describe('download module test suite', () => {
         data: {
           assets: [
             {
-              name: 'cri-dockerd-0.2.3-3.el7.src.rpm',
+              name: 'cri-dockerd-0.3.0-3.el7.src.rpm',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3-3.el7.src.rpm',
+              name: 'cri-dockerd-0.3.0-3.el7.src.rpm',
               browser_download_url: 'http://invalid'
             },
             {
@@ -183,11 +183,11 @@ describe('download module test suite', () => {
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3.arm64.tgz',
+              name: 'cri-dockerd-0.3.0.arm64.tgz',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3.amd64.tgz',
+              name: 'cri-dockerd-0.3.0.amd64.tgz',
               browser_download_url: 'http://valid'
             },
             {
@@ -210,7 +210,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/v0.2.3',
+          url: 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/v0.3.0',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -149,7 +149,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/v1.25.0',
+          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/v1.26.1',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/download.js
+++ b/src/download.js
@@ -62,7 +62,7 @@ const installCniPlugins = async (inputs = {}) => {
 
 const installCriCtl = async (inputs = {}) => {
   core.info(`Downloading cri-ctl`);
-  const tag = 'v1.25.0';
+  const tag = 'v1.26.1';
   const tar = await downloadGitHubArtifact({
     inputs,
     releaseUrl: `https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/${tag}`,

--- a/src/download.js
+++ b/src/download.js
@@ -78,7 +78,7 @@ const installCriDockerd = async (inputs = {}) => {
   // const tagInfo = await getTagInfo({inputs, releaseUrl});
   // const tag = tagInfo.data.name;
   // const releaseUrl = 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest';
-  const tag = 'v0.2.3';
+  const tag = 'v0.3.0';
   const releaseUrl = `https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/${tag}`;
   const binaryTar = await downloadGitHubArtifact({
     inputs,


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

The cri-dockerd v0.2.0 has a critical bug that can not download large container images. And it was resolved in v0.2.6.

ref: 
- https://github.com/kubernetes/minikube/issues/14789
- https://github.com/Mirantis/cri-dockerd/pull/108
- https://github.com/Mirantis/cri-dockerd/commit/460da8ef84e7d2781ee275907543764b6a77c5ff