### PR TITLE
fix: use explicit crictl version (v1.25.0)

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        kubernetes: [v1.25.0,v1.24.3,v1.23.9,v1.22.12]
+        kubernetes: [v1.25.4,v1.24.4,v1.23.14,v1.22.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.1
+          minikube version: v1.28.0
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate Minikube
@@ -41,8 +41,8 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.1
-          kubernetes version: v1.24.3
+          minikube version: v1.28.0
+          kubernetes version: v1.25.4
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
       - name: Validate Minikube
@@ -64,8 +64,8 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.1
-          kubernetes version: v1.24.3
+          minikube version: v1.28.0
+          kubernetes version: v1.25.4
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=registry --addons=metrics-server'
       - name: Validate Minikube
@@ -85,8 +85,8 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.1
-          kubernetes version: v1.24.3
+          minikube version: v1.28.0
+          kubernetes version: v1.25.4
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
       - name: Validate Minikube
@@ -110,7 +110,7 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.0
+          minikube version: v1.28.0
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           container runtime: ${{ matrix.container_runtime }}
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        kubernetes: [v1.21.14,v1.20.15,v1.19.16,v1.18.20,v1.17.17]
+        kubernetes: [v1.22.15,v1.21.14,v1.20.15,v1.19.16,v1.18.20,v1.17.17]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -135,7 +135,7 @@ jobs:
       - name: Test Action
         uses: ./
         with:
-          minikube version: v1.26.0
+          minikube version: v1.28.0
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate Minikube
@@ -156,7 +156,7 @@ jobs:
         uses: ./
         with:
           minikube version: v1.16.0
-          kubernetes version: v1.12.0
+          kubernetes version: v1.12.10
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--force'
       - name: Validate Minikube

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.7.1
         with:
-          minikube version: 'v1.26.1'
-          kubernetes version: 'v1.25.0'
+          minikube version: 'v1.28.0'
+          kubernetes version: 'v1.25.4'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Interact with the cluster
         run: kubectl get nodes

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -96,7 +96,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/latest',
+          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/v1.25.0',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/download.js
+++ b/src/download.js
@@ -45,9 +45,10 @@ const downloadMinikube = async (inputs = {}) => {
 
 const installCriCtl = async (inputs = {}) => {
   core.info(`Downloading cri-ctl`);
+  const tag = 'v1.25.0';
   const tar = await downloadGitHubArtifact({
     inputs,
-    releaseUrl: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/latest',
+    releaseUrl: `https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/${tag}`,
     assetPredicate: asset =>
       isLinux(asset.name) && isAmd64(asset.name) && !isSignature(asset.name) && asset.name.indexOf('crictl') === 0
   });
@@ -78,7 +79,6 @@ const installCriDockerd = async (inputs = {}) => {
   const sourceDir = await tc.extractTar(sourceTar);
   const sourceContent = firstDir(sourceDir);
   logExecSync(`sed -i 's/cri-dockerd --/cri-dockerd --network-plugin=cni --/g' ${sourceDir}/${sourceContent}/packaging/systemd/cri-docker.service`);
-  logExecSync(`cat ${sourceDir}/${sourceContent}/packaging/systemd/cri-docker.service`);
   logExecSync(`sudo cp -a ${sourceDir}/${sourceContent}/packaging/systemd/* /etc/systemd/system`);
   const serviceFile = '/etc/systemd/system/cri-docker.service';
   fs.writeFileSync(serviceFile, fs.readFileSync(serviceFile).toString()


### PR DESCRIPTION
- fix: use explicit crictl version (v1.25.0)
- ci: bump Minikube versions