### PR TITLE
feat: support CRI

### DIFF
--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -76,19 +76,19 @@ describe('download module test suite', () => {
         data: {
           assets: [
             {
-              name: 'cni-plugins-linux-amd64-v1.2.0.tgz.sha1',
+              name: 'cni-plugins-linux-amd64-v1.3.0.tgz.sha1',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cni-plugins-linux-amd64-v1.2.0.tgz',
+              name: 'cni-plugins-linux-amd64-v1.3.0.tgz',
               browser_download_url: 'http://valid'
             },
             {
-              name: 'cni-plugins-linux-amd64-v1.2.0.tgz.sha512',
+              name: 'cni-plugins-linux-amd64-v1.3.0.tgz.sha512',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cni-plugins-windows-amd64-v1.2.0.tgz',
+              name: 'cni-plugins-windows-amd64-v1.3.0.tgz',
               browser_download_url: 'http://invalid'
             }
           ]
@@ -102,7 +102,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/containernetworking/plugins/releases/tags/v1.2.0',
+          url: 'https://api.github.com/repos/containernetworking/plugins/releases/tags/v1.3.0',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -150,7 +150,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/v1.25.0',
+          url: 'https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/v1.28.0',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -172,11 +172,11 @@ describe('download module test suite', () => {
         data: {
           assets: [
             {
-              name: 'cri-dockerd-0.2.3-3.el7.src.rpm',
+              name: 'cri-dockerd-0.3.4-3.el7.src.rpm',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3-3.el7.src.rpm',
+              name: 'cri-dockerd-0.3.4-3.el7.src.rpm',
               browser_download_url: 'http://invalid'
             },
             {
@@ -184,11 +184,11 @@ describe('download module test suite', () => {
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3.arm64.tgz',
+              name: 'cri-dockerd-0.3.4.arm64.tgz',
               browser_download_url: 'http://invalid'
             },
             {
-              name: 'cri-dockerd-0.2.3.amd64.tgz',
+              name: 'cri-dockerd-0.3.4.amd64.tgz',
               browser_download_url: 'http://valid'
             },
             {
@@ -211,7 +211,7 @@ describe('download module test suite', () => {
       // Then
       expect(axios).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/v0.2.3',
+          url: 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/v0.3.4',
           headers: {Authorization: 'token secret-token'}
         })
       );

--- a/src/download.js
+++ b/src/download.js
@@ -78,7 +78,7 @@ const installCriDockerd = async (inputs = {}) => {
   // const tagInfo = await getTagInfo({inputs, releaseUrl});
   // const tag = tagInfo.data.name;
   // const releaseUrl = 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest';
-  const tag = 'v0.2.3';
+  const tag = 'v0.3.4';
   const releaseUrl = `https://api.github.com/repos/Mirantis/cri-dockerd/releases/tags/${tag}`;
   const binaryTar = await downloadGitHubArtifact({
     inputs,

--- a/src/download.js
+++ b/src/download.js
@@ -62,7 +62,7 @@ const installCniPlugins = async (inputs = {}) => {
 
 const installCriCtl = async (inputs = {}) => {
   core.info(`Downloading cri-ctl`);
-  const tag = 'v1.25.0';
+  const tag = 'v1.28.0';
   const tar = await downloadGitHubArtifact({
     inputs,
     releaseUrl: `https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/tags/${tag}`,

--- a/src/download.js
+++ b/src/download.js
@@ -48,7 +48,7 @@ const downloadMinikube = async (inputs = {}) => {
 // https://github.com/kubernetes/minikube/commit/fd549f396dbd39385baefe88dcead0ccf99f1bff
 const installCniPlugins = async (inputs = {}) => {
   core.info(`Downloading CNI plugins`);
-  const tag = 'v1.2.0';
+  const tag = 'v1.3.0';
   const tar = await downloadGitHubArtifact({
     inputs,
     releaseUrl: `https://api.github.com/repos/containernetworking/plugins/releases/tags/${tag}`,


### PR DESCRIPTION
## Description

Superseded closes #77

Full support for Kubernetes CRI

## Related repositories and releases
- https://github.com/Mirantis/cri-dockerd
- https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.4
- https://github.com/kubernetes-sigs/cri-tools
- https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.28.0
- https://github.com/containernetworking/plugins
- https://github.com/containernetworking/plugins/releases/tag/v1.3.0

## Related events
- [Kubernetes is Moving on From Dockershim: Commitments and Next Steps | Kubernetes](https://kubernetes.io/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/)

## Related issues
- https://github.com/kubernetes/minikube/issues/15870
- https://github.com/kubernetes/minikube/pull/16001
- https://github.com/Mirantis/cri-dockerd/issues/163
- https://github.com/Mirantis/cri-dockerd/issues/104
- https://github.com/Mirantis/cri-dockerd/pull/103 