### PR TITLE
fix: support arm64 runners

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -9,9 +9,10 @@ on:
 jobs:
   default-inputs:
     name: Defaults
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         kubernetes: [v1.35.2,v1.34.5,v1.33.9,v1.32.13,v1.31.14]
     steps:
       - name: Checkout
@@ -32,7 +33,10 @@ jobs:
         run: 'cat $MINIKUBE_HOME/.minikube/machines/minikube/config.json | jq ".DriverName" | grep none'
   docker-driver:
     name: Docker driver
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -59,7 +59,10 @@ jobs:
         run: minikube ssh --native-ssh=false "cat /etc/os-release"
   extra-args:
     name: Extra arguments
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,7 +83,10 @@ jobs:
         run: minikube addons list -o json | jq '.registry.Status' | grep enabled
   ingress:
     name: Ingress enabled
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,9 +107,10 @@ jobs:
         run: minikube addons list -o json | jq '.ingress.Status' | grep enabled
   container-runtime:
     name: Container runtime config in docker driver (Required by containerd)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         kubernetes: [v1.35.2,v1.34.5,v1.33.9,v1.32.13,v1.31.14,v1.26.15]
         container_runtime: ['containerd']
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,16 @@ describe('UserService', () => {
 2. Test locally with `npm test`
 3. Push and verify CI workflows pass
 
+### Adding Support for a New Architecture
+
+Architecture detection lives in `src/arch.js`, which maps `process.arch` to the GitHub release naming convention used by the binaries this action downloads (e.g. `x64` → `amd64`, `arm64` → `arm64`). To add a new architecture:
+
+1. Extend the `switch` in `src/arch.js` with the new `process.arch` value and its GitHub release suffix. Keep the default branch throwing — the strict allow-list is intentional so unsupported runners fail fast.
+2. Add coverage in `src/__tests__/arch.test.js` (the success case) and `src/__tests__/check-environment.test.js` (the fail-fast behavior on unsupported archs).
+3. Add fixtures and an `on <arch> host` describe in `src/__tests__/download.test.js` for each of the four downloads (Minikube, CNI plugins, crictl, cri-dockerd) so the asset predicates are verified end-to-end.
+4. Extend the `os` matrix axis in `.github/workflows/runner.yml` for the jobs that exercise the relevant code path (at minimum `default-inputs` for the `none` driver and `docker-driver` for the docker path).
+5. Confirm the four upstreams publish assets for the new architecture before relying on it — release naming is upstream-defined and not all tags carry every arch.
+
 ### Adding a New Action Input
 
 1. Add input definition in `action.yml`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and [Kubernetes](https://github.com/kubernetes/kubernetes).
 
 _Currently only Linux Ubuntu 18.04, 20.04, 22.04, or 24.04
 [CI environment](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions)
-is supported._
+is supported, on either x64 (amd64) or arm64 (e.g. `ubuntu-24.04-arm`) runners._
 
 ## Usage
 

--- a/src/__tests__/arch.test.js
+++ b/src/__tests__/arch.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+describe('arch module', () => {
+  let arch;
+  let originalArch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalArch = process.arch;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'arch', {value: originalArch});
+  });
+
+  describe('on x64 host', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'arch', {value: 'x64'});
+      ({arch} = require('../arch'));
+    });
+
+    test('returns amd64', () => {
+      expect(arch()).toBe('amd64');
+    });
+  });
+
+  describe('on arm64 host', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'arch', {value: 'arm64'});
+      ({arch} = require('../arch'));
+    });
+
+    test('returns arm64', () => {
+      expect(arch()).toBe('arm64');
+    });
+  });
+
+  describe.each(['ia32', 'arm', 'ppc64', 's390x'])(
+    'on unsupported %s host',
+    unsupported => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: unsupported});
+        ({arch} = require('../arch'));
+      });
+
+      test('throws unsupported architecture error', () => {
+        expect(arch).toThrow(/Unsupported architecture/);
+      });
+    }
+  );
+});

--- a/src/__tests__/check-environment.test.js
+++ b/src/__tests__/check-environment.test.js
@@ -8,14 +8,17 @@ const originalReadFileSync = fs.readFileSync.bind(fs);
 describe('checkEnvironment', () => {
   let checkEnvironment;
   let originalPlatform;
+  let originalArch;
 
   beforeEach(() => {
     jest.resetModules();
     originalPlatform = process.platform;
+    originalArch = process.arch;
   });
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', {value: originalPlatform});
+    Object.defineProperty(process, 'arch', {value: originalArch});
     jest.restoreAllMocks();
   });
 
@@ -82,6 +85,26 @@ describe('checkEnvironment', () => {
 
     test('does not throw', () => {
       expect(checkEnvironment).not.toThrow();
+    });
+
+    describe('on arm64 host', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+      });
+
+      test('does not throw', () => {
+        expect(checkEnvironment).not.toThrow();
+      });
+    });
+
+    describe('on unsupported architecture', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'ppc64'});
+      });
+
+      test('throws unsupported architecture error', () => {
+        expect(checkEnvironment).toThrow(/Unsupported architecture/);
+      });
     });
   });
 });

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -20,6 +20,7 @@ describe('download module', () => {
   let tc;
   let exec;
   let tmpDir;
+  let originalArch;
 
   beforeAll(async () => {
     testServer = createHttpTestServer();
@@ -37,6 +38,7 @@ describe('download module', () => {
     process.env.RUNNER_TEMP = tmpDir;
     process.env.GITHUB_API_URL = baseUrl;
     process.env.GITHUB_SERVER_URL = baseUrl;
+    originalArch = process.arch;
 
     exec = require('../exec');
     download = require('../download');
@@ -51,6 +53,7 @@ describe('download module', () => {
     delete process.env.RUNNER_TEMP;
     delete process.env.GITHUB_API_URL;
     delete process.env.GITHUB_SERVER_URL;
+    Object.defineProperty(process, 'arch', {value: originalArch});
   });
 
   describe('downloadMinikube', () => {
@@ -68,11 +71,22 @@ describe('download module', () => {
           {
             name: 'minikube-linux-amd64.sha256',
             browser_download_url: `${baseUrl}/download/minikube-sha256`
+          },
+          {
+            name: 'minikube-linux-arm64',
+            browser_download_url: `${baseUrl}/download/minikube-linux-arm64`
+          },
+          {
+            name: 'minikube-linux-arm64.sha256',
+            browser_download_url: `${baseUrl}/download/minikube-sha256`
           }
         ]
       });
       testServer.get('/download/minikube-linux-amd64', () => ({
         binary: Buffer.from('fake-minikube-binary')
+      }));
+      testServer.get('/download/minikube-linux-arm64', () => ({
+        binary: Buffer.from('fake-minikube-binary-arm64')
       }));
     });
 
@@ -115,6 +129,44 @@ describe('download module', () => {
         .find(r => r.pathname.includes('/releases/tags/'));
       expect(apiRequest.headers.authorization).toBe('token secret-token');
     });
+
+    describe('on arm64 host', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+      });
+
+      test('selects linux arm64 binary, not amd64', async () => {
+        await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+        const downloadRequests = testServer
+          .getRequests()
+          .filter(r => r.pathname.startsWith('/download/'));
+        expect(downloadRequests).toHaveLength(1);
+        expect(downloadRequests[0].pathname).toBe(
+          '/download/minikube-linux-arm64'
+        );
+      });
+    });
+
+    describe('on arm64 host with no arm64 asset published', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+        testServer.clearRoutes();
+        testServer.get('/repos/kubernetes/minikube/releases/tags/v0.1.0', {
+          assets: [
+            {
+              name: 'minikube-linux-amd64',
+              browser_download_url: `${baseUrl}/download/minikube-linux-amd64`
+            }
+          ]
+        });
+      });
+
+      test('throws an actionable error naming the arch', async () => {
+        await expect(
+          download.downloadMinikube({minikubeVersion: 'v0.1.0'})
+        ).rejects.toThrow(/No matching arm64 asset/);
+      });
+    });
   });
 
   describe('installCniPlugins', () => {
@@ -138,7 +190,7 @@ describe('download module', () => {
             },
             {
               name: 'cni-plugins-linux-amd64-v1.9.0.tgz',
-              browser_download_url: `${baseUrl}/download/cni-plugins.tgz`
+              browser_download_url: `${baseUrl}/download/cni-plugins-amd64.tgz`
             },
             {
               name: 'cni-plugins-linux-amd64-v1.9.0.tgz.sha512',
@@ -147,11 +199,22 @@ describe('download module', () => {
             {
               name: 'cni-plugins-windows-amd64-v1.9.0.tgz',
               browser_download_url: `${baseUrl}/invalid`
+            },
+            {
+              name: 'cni-plugins-linux-arm64-v1.9.0.tgz',
+              browser_download_url: `${baseUrl}/download/cni-plugins-arm64.tgz`
+            },
+            {
+              name: 'cni-plugins-linux-arm64-v1.9.0.tgz.sha512',
+              browser_download_url: `${baseUrl}/invalid`
             }
           ]
         }
       );
-      testServer.get('/download/cni-plugins.tgz', () => ({
+      testServer.get('/download/cni-plugins-amd64.tgz', () => ({
+        binary: cniTarball
+      }));
+      testServer.get('/download/cni-plugins-arm64.tgz', () => ({
         binary: cniTarball
       }));
     });
@@ -190,6 +253,34 @@ describe('download module', () => {
         .find(r => r.pathname.includes('/releases/tags/'));
       expect(apiRequest.headers.authorization).toBe('token secret-token');
     });
+
+    test('selects linux amd64 tarball on x64 host', async () => {
+      await download.installCniPlugins({});
+      const downloadRequests = testServer
+        .getRequests()
+        .filter(r => r.pathname.startsWith('/download/'));
+      expect(downloadRequests).toHaveLength(1);
+      expect(downloadRequests[0].pathname).toBe(
+        '/download/cni-plugins-amd64.tgz'
+      );
+    });
+
+    describe('on arm64 host', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+      });
+
+      test('selects linux arm64 tarball, not amd64', async () => {
+        await download.installCniPlugins({});
+        const downloadRequests = testServer
+          .getRequests()
+          .filter(r => r.pathname.startsWith('/download/'));
+        expect(downloadRequests).toHaveLength(1);
+        expect(downloadRequests[0].pathname).toBe(
+          '/download/cni-plugins-arm64.tgz'
+        );
+      });
+    });
   });
 
   describe('installCriCtl', () => {
@@ -208,15 +299,26 @@ describe('download module', () => {
           },
           {
             name: 'crictl-linux-amd64.tar.gz',
-            browser_download_url: `${baseUrl}/download/crictl.tar.gz`
+            browser_download_url: `${baseUrl}/download/crictl-amd64.tar.gz`
           },
           {
             name: 'crictl-linux-amd64.sha256',
             browser_download_url: `${baseUrl}/invalid`
+          },
+          {
+            name: 'crictl-linux-arm64.tar.gz',
+            browser_download_url: `${baseUrl}/download/crictl-arm64.tar.gz`
+          },
+          {
+            name: 'crictl-linux-arm64.sha256',
+            browser_download_url: `${baseUrl}/invalid`
           }
         ]
       });
-      testServer.get('/download/crictl.tar.gz', () => ({
+      testServer.get('/download/crictl-amd64.tar.gz', () => ({
+        binary: crictlTarball
+      }));
+      testServer.get('/download/crictl-arm64.tar.gz', () => ({
         binary: crictlTarball
       }));
       // extractTar destination is /usr/local/bin (not writable without sudo)
@@ -264,6 +366,34 @@ describe('download module', () => {
         .find(r => r.pathname.includes('/releases/tags/'));
       expect(apiRequest.headers.authorization).toBe('token secret-token');
     });
+
+    test('selects linux amd64 tarball on x64 host', async () => {
+      await download.installCriCtl({});
+      const downloadRequests = testServer
+        .getRequests()
+        .filter(r => r.pathname.startsWith('/download/'));
+      expect(downloadRequests).toHaveLength(1);
+      expect(downloadRequests[0].pathname).toBe(
+        '/download/crictl-amd64.tar.gz'
+      );
+    });
+
+    describe('on arm64 host', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+      });
+
+      test('selects linux arm64 tarball, not amd64', async () => {
+        await download.installCriCtl({});
+        const downloadRequests = testServer
+          .getRequests()
+          .filter(r => r.pathname.startsWith('/download/'));
+        expect(downloadRequests).toHaveLength(1);
+        expect(downloadRequests[0].pathname).toBe(
+          '/download/crictl-arm64.tar.gz'
+        );
+      });
+    });
   });
 
   describe('installCriDockerd', () => {
@@ -298,11 +428,11 @@ describe('download module', () => {
           },
           {
             name: 'cri-dockerd-0.3.4.arm64.tgz',
-            browser_download_url: `${baseUrl}/invalid`
+            browser_download_url: `${baseUrl}/download/cri-dockerd-arm64.tgz`
           },
           {
             name: 'cri-dockerd-0.3.4.amd64.tgz',
-            browser_download_url: `${baseUrl}/download/cri-dockerd.tgz`
+            browser_download_url: `${baseUrl}/download/cri-dockerd-amd64.tgz`
           },
           {
             name: 'cri-dockerd-v0.2.0-linux-amd64.tar.gz.md5',
@@ -310,7 +440,10 @@ describe('download module', () => {
           }
         ]
       });
-      testServer.get('/download/cri-dockerd.tgz', () => ({
+      testServer.get('/download/cri-dockerd-amd64.tgz', () => ({
+        binary: binaryTarball
+      }));
+      testServer.get('/download/cri-dockerd-arm64.tgz', () => ({
         binary: binaryTarball
       }));
       testServer.get(
@@ -351,8 +484,25 @@ describe('download module', () => {
       await download.installCriDockerd({});
       const requests = testServer.getRequests();
       expect(
-        requests.some(r => r.pathname === '/download/cri-dockerd.tgz')
+        requests.some(r => r.pathname === '/download/cri-dockerd-amd64.tgz')
       ).toBe(true);
+    });
+
+    describe('on arm64 host', () => {
+      beforeEach(() => {
+        Object.defineProperty(process, 'arch', {value: 'arm64'});
+      });
+
+      test('selects arm64 tgz, skipping amd64 and darwin', async () => {
+        await download.installCriDockerd({});
+        const requests = testServer.getRequests();
+        expect(
+          requests.some(r => r.pathname === '/download/cri-dockerd-arm64.tgz')
+        ).toBe(true);
+        expect(
+          requests.some(r => r.pathname === '/download/cri-dockerd-amd64.tgz')
+        ).toBe(false);
+      });
     });
 
     test('extracts binary from real tarball', async () => {

--- a/src/arch.js
+++ b/src/arch.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const arch = () => {
+  switch (process.arch) {
+    case 'x64':
+      return 'amd64';
+    case 'arm64':
+      return 'arm64';
+    default:
+      throw new Error(
+        `Unsupported architecture: ${process.arch}. Action only works on x64 (amd64) or arm64 runners.`
+      );
+  }
+};
+
+module.exports = {arch};

--- a/src/check-environment.js
+++ b/src/check-environment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const {arch} = require('./arch');
 
 const isLinux = () => process.platform.toLowerCase().indexOf('linux') === 0;
 const isUbuntu = version => () => {
@@ -24,6 +25,7 @@ const checkOperatingSystem = () => {
 
 const checkEnvironment = () => {
   checkOperatingSystem();
+  arch();
 };
 
 module.exports = checkEnvironment;

--- a/src/download.js
+++ b/src/download.js
@@ -5,9 +5,10 @@ const tc = require('@actions/tool-cache');
 const fs = require('node:fs');
 const {logExecSync} = require('./exec');
 const {gitHubRequest, apiBaseUrl, serverBaseUrl} = require('./github');
+const {arch} = require('./arch');
 
 const isLinux = name => name.indexOf('linux') >= 0;
-const isAmd64 = name => name.indexOf('amd64') >= 0;
+const isArch = name => name.indexOf(arch()) >= 0;
 const isSignature = name =>
   name.indexOf('sha1') >= 0 ||
   name.indexOf('sha256') >= 0 ||
@@ -26,10 +27,14 @@ const downloadGitHubArtifact = async ({inputs, releaseUrl, assetPredicate}) => {
     url: releaseUrl,
     githubToken: inputs.githubToken
   });
-  const downloadUrl =
-    tagInfo.data.assets.find(assetPredicate).browser_download_url;
-  core.info(`Downloading from: ${downloadUrl}`);
-  return tc.downloadTool(downloadUrl);
+  const asset = tagInfo.data.assets.find(assetPredicate);
+  if (!asset) {
+    throw new Error(
+      `No matching ${arch()} asset found at ${releaseUrl}. The release may not publish ${arch()} binaries.`
+    );
+  }
+  core.info(`Downloading from: ${asset.browser_download_url}`);
+  return tc.downloadTool(asset.browser_download_url);
 };
 
 const downloadMinikube = async (inputs = {}) => {
@@ -38,7 +43,7 @@ const downloadMinikube = async (inputs = {}) => {
     inputs,
     releaseUrl: `${apiBaseUrl}/repos/kubernetes/minikube/releases/tags/${inputs.minikubeVersion}`,
     assetPredicate: asset =>
-      isLinux(asset.name) && isAmd64(asset.name) && !isSignature(asset.name)
+      isLinux(asset.name) && isArch(asset.name) && !isSignature(asset.name)
   });
 };
 
@@ -53,7 +58,7 @@ const installCniPlugins = async (inputs = {}) => {
     releaseUrl: `${apiBaseUrl}/repos/containernetworking/plugins/releases/tags/${tag}`,
     assetPredicate: asset =>
       isLinux(asset.name) &&
-      isAmd64(asset.name) &&
+      isArch(asset.name) &&
       !isSignature(asset.name) &&
       asset.name.indexOf('cni-plugins') === 0
   });
@@ -72,7 +77,7 @@ const installCriCtl = async (inputs = {}) => {
     releaseUrl: `${apiBaseUrl}/repos/kubernetes-sigs/cri-tools/releases/tags/${tag}`,
     assetPredicate: asset =>
       isLinux(asset.name) &&
-      isAmd64(asset.name) &&
+      isArch(asset.name) &&
       !isSignature(asset.name) &&
       asset.name.indexOf('crictl') === 0
   });
@@ -94,7 +99,7 @@ const installCriDockerd = async (inputs = {}) => {
       !isSignature(asset.name) &&
       !isWindows(asset.name) &&
       !isMac(asset.name) &&
-      isAmd64(asset.name) &&
+      isArch(asset.name) &&
       isTgz(asset.name) &&
       asset.name.indexOf('cri-dockerd') === 0
   });


### PR DESCRIPTION
## Summary

Fixes #147 — the action hardcoded `amd64` in every binary URL, so on
`ubuntu-24.04-arm` (and any `linux/arm64` runner) it downloaded x86_64
binaries that the kernel could not execute, failing with
`Exec format error`.

## Changes

- New `src/arch.js` maps `process.arch` to the GitHub release naming
  convention: `x64` → `amd64`, `arm64` → `arm64`, and throws on
  unsupported architectures.
- `src/download.js` now uses the arch helper when picking the asset for
  Minikube, CNI plugins, crictl, and cri-dockerd.
- `downloadGitHubArtifact` raises a clear, arch-named error when a
  release does not publish the expected architecture, instead of
  dereferencing `undefined`.
- `checkEnvironment` now fails fast on unsupported architectures.
- E2E `runner.yml` matrix runs `default-inputs` (covers the `none`
  driver path: CNI + crictl + cri-dockerd) and `docker-driver` on both
  `ubuntu-latest` and `ubuntu-24.04-arm`.

## Test plan

- [x] `npm test` — 10 suites, 114 tests passing (was 113 + 1 new
      missing-asset regression test).
- [x] `npm run format-check` — all files use Prettier code style.
- [ ] CI: new `ubuntu-24.04-arm` matrix entries on `default-inputs` and
      `docker-driver` must pass before merge.