### PR TITLE
fix(download): verify SHA256 of downloaded binaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,19 @@ action.yml              # GitHub Action definition (outputs: `force`)
 
 These binaries are downloaded at runtime from GitHub releases. Their versions are hardcoded as `const tag = '...'` values in `src/download.js` (not in `package.json`).
 
+### SHA256 Verification
+
+Every binary downloaded by `src/download.js` is SHA256-verified before use. Verification is enforced by `downloadGitHubArtifact`, which is the single funnel for release-asset downloads — a download cannot bypass it.
+
+Two verification modes:
+
+- **`verifyWithCompanionSha256: true`** — `downloadGitHubArtifact` looks up the `<asset.name>.sha256` companion asset in the same release, fetches its body via `gitHubRequest`, parses the hex digest (first whitespace-separated token), and aborts on mismatch. Used for **minikube**, **CNI plugins**, and **crictl** — all three upstreams publish `.sha256` companions.
+- **`expectedSha256: '<hex>'`** — verifies against a pinned hex value. Used for **cri-dockerd**, whose releases do not publish any checksum companion files. Pinned values live in `src/checksums.js`.
+
+The cri-dockerd source archive (a GitHub auto-generated `archive/refs/tags/<v>.tar.gz`, not a release asset) is downloaded via `tc.downloadTool` directly and verified by calling `verifySha256File` against `checksums.criDockerd.sourceSha256`.
+
+When a verification fails, the action throws and aborts before any extraction or installation. There is no fallback path.
+
 ## Code Style
 
 ### Formatting
@@ -237,15 +250,36 @@ Architecture detection lives in `src/arch.js`, which maps `process.arch` to the 
 
 #### Binary dependency updates (CNI plugins, cri-tools, cri-dockerd)
 
-These are **not** npm packages. Their versions are hardcoded in `src/download.js` as `const tag = '...'` values, and they also have matching version strings in `src/__tests__/download.test.js`.
+These are **not** npm packages. Their versions are hardcoded in `src/download.js` as `const tag = '...'` values (or in `src/checksums.js` for cri-dockerd), and they also have matching version strings in `src/__tests__/download.test.js`.
 
 **To update a binary dependency:**
 
 1. Check the latest release on the corresponding GitHub repo
-2. Update the `const tag` value in `src/download.js`
+2. Update the `const tag` value in `src/download.js` (or `criDockerd.tag` in `src/checksums.js` for cri-dockerd)
 3. Update the matching URL in `src/__tests__/download.test.js`
-4. Run tests: `npm test`
-5. **Create a separate pull request** (not just a commit) for each binary dependency update — these changes require E2E validation via the `runner.yml` workflow to verify Minikube still starts correctly with the new versions
+4. **For cri-dockerd only**: also recompute and update the pinned SHA256 digests — see "Rotating the cri-dockerd pinned digests" below
+5. Run tests: `npm test`
+6. **Create a separate pull request** (not just a commit) for each binary dependency update — these changes require E2E validation via the `runner.yml` workflow to verify Minikube still starts correctly with the new versions
+
+#### Rotating the cri-dockerd pinned digests
+
+cri-dockerd publishes no `.sha256` companion assets, so its checksums are pinned in `src/checksums.js`. The minikube, CNI plugins, and crictl downloads consume their upstream `.sha256` companions automatically — no pinned values to maintain for those.
+
+When bumping `criDockerd.tag`, recompute all three digests:
+
+```shell
+TAG=v0.3.25  # the new tag
+curl -sLo /tmp/cri-dockerd-amd64.tgz "https://github.com/Mirantis/cri-dockerd/releases/download/${TAG}/cri-dockerd-${TAG#v}.amd64.tgz"
+curl -sLo /tmp/cri-dockerd-arm64.tgz "https://github.com/Mirantis/cri-dockerd/releases/download/${TAG}/cri-dockerd-${TAG#v}.arm64.tgz"
+curl -sLo /tmp/cri-dockerd-source.tar.gz "https://github.com/Mirantis/cri-dockerd/archive/refs/tags/${TAG}.tar.gz"
+sha256sum /tmp/cri-dockerd-amd64.tgz /tmp/cri-dockerd-arm64.tgz /tmp/cri-dockerd-source.tar.gz
+```
+
+Paste the three hex values into `criDockerd.binarySha256.amd64`, `criDockerd.binarySha256.arm64`, and `criDockerd.sourceSha256` respectively. Mismatches at runtime cause the action to abort before installing anything, so getting these wrong is loud (action fails) rather than silent.
+
+**Common mistakes to avoid:**
+- **Forgetting to update the source archive digest**: `sourceSha256` is for the GitHub auto-generated archive (`archive/refs/tags/<tag>.tar.gz`), not a release asset — easy to miss because it isn't listed under "Assets" on the release page.
+- **Bumping `tag` without updating digests**: the action will fail at the first download with `SHA256 mismatch for cri-dockerd-<v>.<arch>.tgz`.
 
 ### Releasing a New Version
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,14 +89,19 @@ These binaries are downloaded at runtime from GitHub releases. Their versions ar
 
 ### SHA256 Verification
 
-Every binary downloaded by `src/download.js` is SHA256-verified before use. Verification is enforced by `downloadGitHubArtifact`, which is the single funnel for release-asset downloads — a download cannot bypass it.
+Every binary downloaded by `src/download.js` is SHA256-verified before use. Two helpers funnel all downloads — **no bare `tc.downloadTool` call should appear in this module**:
 
-Two verification modes:
+- **`downloadGitHubArtifact(...)`** — for release-asset downloads. Requires exactly one of:
+  - **`verifyWithCompanionSha256: true`** — looks up the `<asset.name>.sha256` companion asset in the same release, fetches its body via `gitHubRequest` (with `responseType: 'text'`), parses the leading hex token, validates the format with `assertSha256Hex`, and aborts on mismatch. Used for **minikube**, **CNI plugins**, and **crictl** — all three upstreams publish `.sha256` companions.
+  - **`expectedSha256: '<hex>'`** — verifies against a pinned hex value. Used for **cri-dockerd**, whose releases do not publish any checksum companion files. Pinned values live in `src/checksums.js`.
 
-- **`verifyWithCompanionSha256: true`** — `downloadGitHubArtifact` looks up the `<asset.name>.sha256` companion asset in the same release, fetches its body via `gitHubRequest`, parses the hex digest (first whitespace-separated token), and aborts on mismatch. Used for **minikube**, **CNI plugins**, and **crictl** — all three upstreams publish `.sha256` companions.
-- **`expectedSha256: '<hex>'`** — verifies against a pinned hex value. Used for **cri-dockerd**, whose releases do not publish any checksum companion files. Pinned values live in `src/checksums.js`.
+  Passing both options throws "both provided"; passing neither throws "neither provided" — the funnel is fail-loud on misuse.
 
-The cri-dockerd source archive (a GitHub auto-generated `archive/refs/tags/<v>.tar.gz`, not a release asset) is downloaded via `tc.downloadTool` directly and verified by calling `verifySha256File` against `checksums.criDockerd.sourceSha256`.
+- **`downloadVerifiedUrl({url, expectedSha256, label})`** — for direct-URL downloads that aren't release assets (e.g. the cri-dockerd source archive at `github.com/<repo>/archive/refs/tags/<v>.tar.gz`). Pairs `tc.downloadTool` with `verifySha256File` so download and verification cannot drift apart.
+
+When `installCriDockerd` runs on an arch with no pinned digest in `checksums.criDockerd.binarySha256`, it throws an arch-specific error before reaching the funnel ("No pinned SHA256 for arch=…") — adding a new arch to `src/arch.js` without updating `src/checksums.js` fails fast with a self-diagnosing message.
+
+`verifySha256File` and the parser both call `assertSha256Hex` to reject non-hex / wrong-length inputs early, so a malformed companion response or a typo in `checksums.js` surfaces as "Invalid SHA256 digest" rather than a generic mismatch.
 
 When a verification fails, the action throws and aborts before any extraction or installation. There is no fallback path.
 

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -1,14 +1,11 @@
 'use strict';
 
-const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const {createHttpTestServer} = require('./test-utils/http-test-server');
 const {createTarball} = require('./test-utils/create-tarball');
-
-const sha256Hex = buffer =>
-  crypto.createHash('sha256').update(buffer).digest('hex');
+const {sha256Hex} = require('./test-utils/sha256-hex');
 
 // Only mock system commands that require root/sudo
 jest.mock('../exec');
@@ -58,6 +55,31 @@ describe('download module', () => {
     delete process.env.GITHUB_API_URL;
     delete process.env.GITHUB_SERVER_URL;
     Object.defineProperty(process, 'arch', {value: originalArch});
+  });
+
+  describe('downloadGitHubArtifact verification guard', () => {
+    test('throws when both verifyWithCompanionSha256 and expectedSha256 are provided', async () => {
+      await expect(
+        download.downloadGitHubArtifact({
+          inputs: {},
+          releaseUrl: `${baseUrl}/some/release`,
+          assetPredicate: () => true,
+          verifyWithCompanionSha256: true,
+          expectedSha256:
+            '0000000000000000000000000000000000000000000000000000000000000000'
+        })
+      ).rejects.toThrow(/both .* were provided/);
+    });
+
+    test('throws when neither verification option is provided', async () => {
+      await expect(
+        download.downloadGitHubArtifact({
+          inputs: {},
+          releaseUrl: `${baseUrl}/some/release`,
+          assetPredicate: () => true
+        })
+      ).rejects.toThrow(/neither .* was provided/);
+    });
   });
 
   describe('downloadMinikube', () => {
@@ -244,6 +266,25 @@ describe('download module', () => {
         expect(error.message).toMatch(
           /No .*\.sha256.* companion.*minikube-linux-amd64/
         );
+      });
+    });
+
+    describe('with a malformed .sha256 companion response (empty body)', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.get('/download/minikube-linux-amd64.sha256', () => ({
+          binary: Buffer.from('')
+        }));
+        try {
+          await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws indicating the malformed digest', () => {
+        expect(error.message).toMatch(/Invalid SHA256 digest/);
       });
     });
   });
@@ -870,6 +911,33 @@ describe('download module', () => {
       test('throws naming the asset', () => {
         expect(error.message).toMatch(
           /SHA256 mismatch.*cri-dockerd-0\.3\.4\.amd64\.tgz/
+        );
+      });
+    });
+
+    describe('with no pinned digest for the current arch', () => {
+      let error;
+
+      beforeEach(async () => {
+        jest.resetModules();
+        jest.doMock('../checksums', () => ({
+          criDockerd: {
+            tag: 'v0.3.24',
+            binarySha256: {},
+            sourceSha256: sourceTarballSha
+          }
+        }));
+        const archlessDownload = require('../download');
+        try {
+          await archlessDownload.installCriDockerd({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws an arch-specific diagnostic', () => {
+        expect(error.message).toMatch(
+          /No pinned SHA256 for arch=.* in checksums\.criDockerd\.binarySha256/
         );
       });
     });

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const {createHttpTestServer} = require('./test-utils/http-test-server');
 const {createTarball} = require('./test-utils/create-tarball');
+
+const sha256Hex = buffer =>
+  crypto.createHash('sha256').update(buffer).digest('hex');
 
 // Only mock system commands that require root/sudo
 jest.mock('../exec');
@@ -57,6 +61,9 @@ describe('download module', () => {
   });
 
   describe('downloadMinikube', () => {
+    const amd64Binary = Buffer.from('fake-minikube-binary');
+    const arm64Binary = Buffer.from('fake-minikube-binary-arm64');
+
     beforeEach(() => {
       testServer.get('/repos/kubernetes/minikube/releases/tags/v1.33.7', {
         assets: [
@@ -70,7 +77,7 @@ describe('download module', () => {
           },
           {
             name: 'minikube-linux-amd64.sha256',
-            browser_download_url: `${baseUrl}/download/minikube-sha256`
+            browser_download_url: `${baseUrl}/download/minikube-linux-amd64.sha256`
           },
           {
             name: 'minikube-linux-arm64',
@@ -78,15 +85,21 @@ describe('download module', () => {
           },
           {
             name: 'minikube-linux-arm64.sha256',
-            browser_download_url: `${baseUrl}/download/minikube-sha256`
+            browser_download_url: `${baseUrl}/download/minikube-linux-arm64.sha256`
           }
         ]
       });
       testServer.get('/download/minikube-linux-amd64', () => ({
-        binary: Buffer.from('fake-minikube-binary')
+        binary: amd64Binary
       }));
       testServer.get('/download/minikube-linux-arm64', () => ({
-        binary: Buffer.from('fake-minikube-binary-arm64')
+        binary: arm64Binary
+      }));
+      testServer.get('/download/minikube-linux-amd64.sha256', () => ({
+        binary: Buffer.from(`${sha256Hex(amd64Binary)}\n`)
+      }));
+      testServer.get('/download/minikube-linux-arm64.sha256', () => ({
+        binary: Buffer.from(`${sha256Hex(arm64Binary)}\n`)
       }));
     });
 
@@ -101,7 +114,11 @@ describe('download module', () => {
       await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
       const downloadRequests = testServer
         .getRequests()
-        .filter(r => r.pathname.startsWith('/download/'));
+        .filter(
+          r =>
+            r.pathname.startsWith('/download/') &&
+            !r.pathname.endsWith('.sha256')
+        );
       expect(downloadRequests).toHaveLength(1);
       expect(downloadRequests[0].pathname).toBe(
         '/download/minikube-linux-amd64'
@@ -117,6 +134,15 @@ describe('download module', () => {
           })
         ])
       );
+    });
+
+    test('fetches the .sha256 companion asset', async () => {
+      await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+      expect(
+        testServer
+          .getRequests()
+          .some(r => r.pathname === '/download/minikube-linux-amd64.sha256')
+      ).toBe(true);
     });
 
     test('forwards github token', async () => {
@@ -139,7 +165,11 @@ describe('download module', () => {
         await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
         const downloadRequests = testServer
           .getRequests()
-          .filter(r => r.pathname.startsWith('/download/'));
+          .filter(
+            r =>
+              r.pathname.startsWith('/download/') &&
+              !r.pathname.endsWith('.sha256')
+          );
         expect(downloadRequests).toHaveLength(1);
         expect(downloadRequests[0].pathname).toBe(
           '/download/minikube-linux-arm64'
@@ -165,6 +195,55 @@ describe('download module', () => {
         await expect(
           download.downloadMinikube({minikubeVersion: 'v0.1.0'})
         ).rejects.toThrow(/No matching arm64 asset/);
+      });
+    });
+
+    describe('with a tampered binary (sha256 mismatch)', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.get('/download/minikube-linux-amd64.sha256', () => ({
+          binary: Buffer.from(`${'0'.repeat(64)}\n`)
+        }));
+        try {
+          await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws naming the asset', () => {
+        expect(error.message).toMatch(/SHA256 mismatch.*minikube-linux-amd64/);
+      });
+    });
+
+    describe('with no .sha256 companion asset published', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.clearRoutes();
+        testServer.get('/repos/kubernetes/minikube/releases/tags/v1.33.7', {
+          assets: [
+            {
+              name: 'minikube-linux-amd64',
+              browser_download_url: `${baseUrl}/download/minikube-linux-amd64`
+            }
+          ]
+        });
+        testServer.get('/download/minikube-linux-amd64', () => ({
+          binary: amd64Binary
+        }));
+        try {
+          await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws indicating the missing companion', () => {
+        expect(error.message).toMatch(
+          /No .*\.sha256.* companion.*minikube-linux-amd64/
+        );
       });
     });
   });
@@ -193,6 +272,10 @@ describe('download module', () => {
               browser_download_url: `${baseUrl}/download/cni-plugins-amd64.tgz`
             },
             {
+              name: 'cni-plugins-linux-amd64-v1.9.0.tgz.sha256',
+              browser_download_url: `${baseUrl}/download/cni-plugins-amd64.tgz.sha256`
+            },
+            {
               name: 'cni-plugins-linux-amd64-v1.9.0.tgz.sha512',
               browser_download_url: `${baseUrl}/invalid`
             },
@@ -203,6 +286,10 @@ describe('download module', () => {
             {
               name: 'cni-plugins-linux-arm64-v1.9.0.tgz',
               browser_download_url: `${baseUrl}/download/cni-plugins-arm64.tgz`
+            },
+            {
+              name: 'cni-plugins-linux-arm64-v1.9.0.tgz.sha256',
+              browser_download_url: `${baseUrl}/download/cni-plugins-arm64.tgz.sha256`
             },
             {
               name: 'cni-plugins-linux-arm64-v1.9.0.tgz.sha512',
@@ -216,6 +303,16 @@ describe('download module', () => {
       }));
       testServer.get('/download/cni-plugins-arm64.tgz', () => ({
         binary: cniTarball
+      }));
+      testServer.get('/download/cni-plugins-amd64.tgz.sha256', () => ({
+        binary: Buffer.from(
+          `${sha256Hex(cniTarball)}  cni-plugins-linux-amd64-v1.9.0.tgz\n`
+        )
+      }));
+      testServer.get('/download/cni-plugins-arm64.tgz.sha256', () => ({
+        binary: Buffer.from(
+          `${sha256Hex(cniTarball)}  cni-plugins-linux-arm64-v1.9.0.tgz\n`
+        )
       }));
     });
 
@@ -246,6 +343,15 @@ describe('download module', () => {
       );
     });
 
+    test('fetches the .sha256 companion asset', async () => {
+      await download.installCniPlugins({});
+      expect(
+        testServer
+          .getRequests()
+          .some(r => r.pathname === '/download/cni-plugins-amd64.tgz.sha256')
+      ).toBe(true);
+    });
+
     test('forwards github token', async () => {
       await download.installCniPlugins({githubToken: 'secret-token'});
       const apiRequest = testServer
@@ -258,7 +364,11 @@ describe('download module', () => {
       await download.installCniPlugins({});
       const downloadRequests = testServer
         .getRequests()
-        .filter(r => r.pathname.startsWith('/download/'));
+        .filter(
+          r =>
+            r.pathname.startsWith('/download/') &&
+            !r.pathname.endsWith('.sha256')
+        );
       expect(downloadRequests).toHaveLength(1);
       expect(downloadRequests[0].pathname).toBe(
         '/download/cni-plugins-amd64.tgz'
@@ -274,10 +384,70 @@ describe('download module', () => {
         await download.installCniPlugins({});
         const downloadRequests = testServer
           .getRequests()
-          .filter(r => r.pathname.startsWith('/download/'));
+          .filter(
+            r =>
+              r.pathname.startsWith('/download/') &&
+              !r.pathname.endsWith('.sha256')
+          );
         expect(downloadRequests).toHaveLength(1);
         expect(downloadRequests[0].pathname).toBe(
           '/download/cni-plugins-arm64.tgz'
+        );
+      });
+    });
+
+    describe('with a tampered tarball (sha256 mismatch)', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.get('/download/cni-plugins-amd64.tgz.sha256', () => ({
+          binary: Buffer.from(
+            `${'0'.repeat(64)}  cni-plugins-linux-amd64-v1.9.0.tgz\n`
+          )
+        }));
+        try {
+          await download.installCniPlugins({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws naming the asset', () => {
+        expect(error.message).toMatch(
+          /SHA256 mismatch.*cni-plugins-linux-amd64-v1\.9\.0\.tgz/
+        );
+      });
+    });
+
+    describe('with no .sha256 companion asset published', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.clearRoutes();
+        testServer.get(
+          '/repos/containernetworking/plugins/releases/tags/v1.9.0',
+          {
+            assets: [
+              {
+                name: 'cni-plugins-linux-amd64-v1.9.0.tgz',
+                browser_download_url: `${baseUrl}/download/cni-plugins-amd64.tgz`
+              }
+            ]
+          }
+        );
+        testServer.get('/download/cni-plugins-amd64.tgz', () => ({
+          binary: cniTarball
+        }));
+        try {
+          await download.installCniPlugins({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws indicating the missing companion', () => {
+        expect(error.message).toMatch(
+          /No .*\.sha256.* companion.*cni-plugins-linux-amd64-v1\.9\.0\.tgz/
         );
       });
     });
@@ -302,16 +472,16 @@ describe('download module', () => {
             browser_download_url: `${baseUrl}/download/crictl-amd64.tar.gz`
           },
           {
-            name: 'crictl-linux-amd64.sha256',
-            browser_download_url: `${baseUrl}/invalid`
+            name: 'crictl-linux-amd64.tar.gz.sha256',
+            browser_download_url: `${baseUrl}/download/crictl-amd64.tar.gz.sha256`
           },
           {
             name: 'crictl-linux-arm64.tar.gz',
             browser_download_url: `${baseUrl}/download/crictl-arm64.tar.gz`
           },
           {
-            name: 'crictl-linux-arm64.sha256',
-            browser_download_url: `${baseUrl}/invalid`
+            name: 'crictl-linux-arm64.tar.gz.sha256',
+            browser_download_url: `${baseUrl}/download/crictl-arm64.tar.gz.sha256`
           }
         ]
       });
@@ -320,6 +490,16 @@ describe('download module', () => {
       }));
       testServer.get('/download/crictl-arm64.tar.gz', () => ({
         binary: crictlTarball
+      }));
+      testServer.get('/download/crictl-amd64.tar.gz.sha256', () => ({
+        binary: Buffer.from(
+          `${sha256Hex(crictlTarball)}  crictl-linux-amd64.tar.gz\n`
+        )
+      }));
+      testServer.get('/download/crictl-arm64.tar.gz.sha256', () => ({
+        binary: Buffer.from(
+          `${sha256Hex(crictlTarball)}  crictl-linux-arm64.tar.gz\n`
+        )
       }));
       // extractTar destination is /usr/local/bin (not writable without sudo)
       jest.spyOn(tc, 'extractTar').mockImplementation(async tarPath => {
@@ -359,6 +539,15 @@ describe('download module', () => {
       );
     });
 
+    test('fetches the .sha256 companion asset', async () => {
+      await download.installCriCtl({});
+      expect(
+        testServer
+          .getRequests()
+          .some(r => r.pathname === '/download/crictl-amd64.tar.gz.sha256')
+      ).toBe(true);
+    });
+
     test('forwards github token', async () => {
       await download.installCriCtl({githubToken: 'secret-token'});
       const apiRequest = testServer
@@ -371,7 +560,11 @@ describe('download module', () => {
       await download.installCriCtl({});
       const downloadRequests = testServer
         .getRequests()
-        .filter(r => r.pathname.startsWith('/download/'));
+        .filter(
+          r =>
+            r.pathname.startsWith('/download/') &&
+            !r.pathname.endsWith('.sha256')
+        );
       expect(downloadRequests).toHaveLength(1);
       expect(downloadRequests[0].pathname).toBe(
         '/download/crictl-amd64.tar.gz'
@@ -387,10 +580,68 @@ describe('download module', () => {
         await download.installCriCtl({});
         const downloadRequests = testServer
           .getRequests()
-          .filter(r => r.pathname.startsWith('/download/'));
+          .filter(
+            r =>
+              r.pathname.startsWith('/download/') &&
+              !r.pathname.endsWith('.sha256')
+          );
         expect(downloadRequests).toHaveLength(1);
         expect(downloadRequests[0].pathname).toBe(
           '/download/crictl-arm64.tar.gz'
+        );
+      });
+    });
+
+    describe('with a tampered tarball (sha256 mismatch)', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.get('/download/crictl-amd64.tar.gz.sha256', () => ({
+          binary: Buffer.from(`${'0'.repeat(64)}  crictl-linux-amd64.tar.gz\n`)
+        }));
+        try {
+          await download.installCriCtl({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws naming the asset', () => {
+        expect(error.message).toMatch(
+          /SHA256 mismatch.*crictl-linux-amd64\.tar\.gz/
+        );
+      });
+    });
+
+    describe('with no .sha256 companion asset published', () => {
+      let error;
+
+      beforeEach(async () => {
+        testServer.clearRoutes();
+        testServer.get(
+          '/repos/kubernetes-sigs/cri-tools/releases/tags/v1.35.0',
+          {
+            assets: [
+              {
+                name: 'crictl-linux-amd64.tar.gz',
+                browser_download_url: `${baseUrl}/download/crictl-amd64.tar.gz`
+              }
+            ]
+          }
+        );
+        testServer.get('/download/crictl-amd64.tar.gz', () => ({
+          binary: crictlTarball
+        }));
+        try {
+          await download.installCriCtl({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws indicating the missing companion', () => {
+        expect(error.message).toMatch(
+          /No .*\.sha256.* companion.*crictl-linux-amd64\.tar\.gz/
         );
       });
     });
@@ -399,6 +650,8 @@ describe('download module', () => {
   describe('installCriDockerd', () => {
     let binaryTarball;
     let sourceTarball;
+    let binaryTarballSha;
+    let sourceTarballSha;
     // In-memory file system for /etc/ paths (not writable without sudo)
     // Content must match the tarball — both are initialized from the same constants
     let serviceFiles;
@@ -413,9 +666,25 @@ describe('download module', () => {
         'cri-dockerd-v0.3.24/packaging/systemd/cri-docker.socket':
           SOCKET_FILE_CONTENT
       });
+      binaryTarballSha = sha256Hex(binaryTarball);
+      sourceTarballSha = sha256Hex(sourceTarball);
     });
 
     beforeEach(() => {
+      jest.resetModules();
+      jest.doMock('../checksums', () => ({
+        criDockerd: {
+          tag: 'v0.3.24',
+          binarySha256: {
+            amd64: binaryTarballSha,
+            arm64: binaryTarballSha
+          },
+          sourceSha256: sourceTarballSha
+        }
+      }));
+      exec = require('../exec');
+      download = require('../download');
+      tc = require('@actions/tool-cache');
       testServer.get('/repos/Mirantis/cri-dockerd/releases/tags/v0.3.24', {
         assets: [
           {
@@ -573,6 +842,64 @@ describe('download module', () => {
           })
         ])
       );
+    });
+
+    describe('with a tampered binary tarball (sha256 mismatch)', () => {
+      let error;
+
+      beforeEach(async () => {
+        jest.resetModules();
+        jest.doMock('../checksums', () => ({
+          criDockerd: {
+            tag: 'v0.3.24',
+            binarySha256: {
+              amd64: '0'.repeat(64),
+              arm64: '0'.repeat(64)
+            },
+            sourceSha256: sourceTarballSha
+          }
+        }));
+        const tamperedDownload = require('../download');
+        try {
+          await tamperedDownload.installCriDockerd({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws naming the asset', () => {
+        expect(error.message).toMatch(
+          /SHA256 mismatch.*cri-dockerd-0\.3\.4\.amd64\.tgz/
+        );
+      });
+    });
+
+    describe('with a tampered source tarball (sha256 mismatch)', () => {
+      let error;
+
+      beforeEach(async () => {
+        jest.resetModules();
+        jest.doMock('../checksums', () => ({
+          criDockerd: {
+            tag: 'v0.3.24',
+            binarySha256: {
+              amd64: binaryTarballSha,
+              arm64: binaryTarballSha
+            },
+            sourceSha256: '0'.repeat(64)
+          }
+        }));
+        const tamperedDownload = require('../download');
+        try {
+          await tamperedDownload.installCriDockerd({});
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      test('throws naming the source archive', () => {
+        expect(error.message).toMatch(/SHA256 mismatch.*cri-dockerd source/);
+      });
     });
   });
 });

--- a/src/__tests__/test-utils/sha256-hex.js
+++ b/src/__tests__/test-utils/sha256-hex.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+const sha256Hex = buffer =>
+  crypto.createHash('sha256').update(buffer).digest('hex');
+
+module.exports = {sha256Hex};

--- a/src/checksums.js
+++ b/src/checksums.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Pinned SHA256 digests for upstream release artifacts that do not publish
+// checksum companion assets alongside their downloads. Verified by
+// `src/download.js` after each download.
+//
+// To rotate (see AGENTS.md > Updating Dependencies > Binary dependency updates):
+//   1. Bump `tag`.
+//   2. Download each artifact from the new release.
+//   3. Recompute every digest with `sha256sum` and update the entries below.
+//   4. Bump the matching tag in `src/download.js` and the fixture in
+//      `src/__tests__/download.test.js`.
+module.exports = {
+  // Mirantis/cri-dockerd publishes only .deb/.rpm/.tgz assets — no .sha256 companion files.
+  criDockerd: {
+    tag: 'v0.3.24',
+    binarySha256: {
+      amd64: 'dd4b7f514c248a3aaca398f467430a4c58aae9a77ea8b96a2f5b5d6fba0948d1',
+      arm64: 'c783a03735887c4a8fc894bd4cf7a1c0defef3ecf50a4d79ff31eed45c26b17e'
+    },
+    sourceSha256:
+      'f8dddd936a9b30594eae459c65b4f1dc98152ee49e15c47b9df930a0ba4d7d88'
+  }
+};

--- a/src/download.js
+++ b/src/download.js
@@ -2,10 +2,12 @@
 
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const {logExecSync} = require('./exec');
 const {gitHubRequest, apiBaseUrl, serverBaseUrl} = require('./github');
 const {arch} = require('./arch');
+const checksums = require('./checksums');
 
 const isLinux = name => name.indexOf('linux') >= 0;
 const isArch = name => name.indexOf(arch()) >= 0;
@@ -22,7 +24,47 @@ const firstDir = dir =>
     .filter(f => f.isDirectory())
     .map(f => f.name)[0];
 
-const downloadGitHubArtifact = async ({inputs, releaseUrl, assetPredicate}) => {
+const verifySha256File = async (filePath, expectedHex, label) => {
+  const actual = crypto
+    .createHash('sha256')
+    .update(await fs.promises.readFile(filePath))
+    .digest('hex');
+  if (actual !== expectedHex) {
+    throw new Error(
+      `SHA256 mismatch for ${label}: expected ${expectedHex}, got ${actual}`
+    );
+  }
+};
+
+const fetchCompanionSha256 = async ({asset, assets, inputs}) => {
+  const digestAsset = assets.find(a => a.name === `${asset.name}.sha256`);
+  if (!digestAsset) {
+    throw new Error(
+      `No .sha256 companion asset published for ${asset.name}. Refusing to install an unverified binary.`
+    );
+  }
+  // `responseType: 'text'` defends against axios JSON auto-decoding the
+  // checksum body if a future GitHub change ever sets application/json on it.
+  const response = await gitHubRequest({
+    url: digestAsset.browser_download_url,
+    githubToken: inputs.githubToken,
+    options: {responseType: 'text'}
+  });
+  return String(response.data).trim().split(/\s+/)[0];
+};
+
+const downloadGitHubArtifact = async ({
+  inputs,
+  releaseUrl,
+  assetPredicate,
+  verifyWithCompanionSha256 = false,
+  expectedSha256
+}) => {
+  if (verifyWithCompanionSha256 === Boolean(expectedSha256)) {
+    throw new Error(
+      'downloadGitHubArtifact requires exactly one of `verifyWithCompanionSha256` or `expectedSha256`'
+    );
+  }
   const tagInfo = await gitHubRequest({
     url: releaseUrl,
     githubToken: inputs.githubToken
@@ -34,7 +76,18 @@ const downloadGitHubArtifact = async ({inputs, releaseUrl, assetPredicate}) => {
     );
   }
   core.info(`Downloading from: ${asset.browser_download_url}`);
-  return tc.downloadTool(asset.browser_download_url);
+  const downloadedFile = await tc.downloadTool(asset.browser_download_url);
+  if (verifyWithCompanionSha256) {
+    const expected = await fetchCompanionSha256({
+      asset,
+      assets: tagInfo.data.assets,
+      inputs
+    });
+    await verifySha256File(downloadedFile, expected, asset.name);
+  } else {
+    await verifySha256File(downloadedFile, expectedSha256, asset.name);
+  }
+  return downloadedFile;
 };
 
 const downloadMinikube = async (inputs = {}) => {
@@ -43,7 +96,8 @@ const downloadMinikube = async (inputs = {}) => {
     inputs,
     releaseUrl: `${apiBaseUrl}/repos/kubernetes/minikube/releases/tags/${inputs.minikubeVersion}`,
     assetPredicate: asset =>
-      isLinux(asset.name) && isArch(asset.name) && !isSignature(asset.name)
+      isLinux(asset.name) && isArch(asset.name) && !isSignature(asset.name),
+    verifyWithCompanionSha256: true
   });
 };
 
@@ -60,7 +114,8 @@ const installCniPlugins = async (inputs = {}) => {
       isLinux(asset.name) &&
       isArch(asset.name) &&
       !isSignature(asset.name) &&
-      asset.name.indexOf('cni-plugins') === 0
+      asset.name.indexOf('cni-plugins') === 0,
+    verifyWithCompanionSha256: true
   });
   const extractedTarDir = await tc.extractTar(tar);
   const cniBinDirPath = '/opt/cni/bin';
@@ -79,18 +134,17 @@ const installCriCtl = async (inputs = {}) => {
       isLinux(asset.name) &&
       isArch(asset.name) &&
       !isSignature(asset.name) &&
-      asset.name.indexOf('crictl') === 0
+      asset.name.indexOf('crictl') === 0,
+    verifyWithCompanionSha256: true
   });
   await tc.extractTar(tar, '/usr/local/bin');
 };
 
 const installCriDockerd = async (inputs = {}) => {
   core.info(`Downloading cri-dockerd`);
-  // In case there are future releases, we can explore the usage of the latest release
-  // const tagInfo = await getTagInfo({inputs, releaseUrl});
-  // const tag = tagInfo.data.name;
-  // const releaseUrl = 'https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest';
-  const tag = 'v0.3.24';
+  // Pinned digests live in ./checksums.js because cri-dockerd does not publish
+  // .sha256 companion assets for its .tgz or source archives.
+  const {tag, binarySha256, sourceSha256} = checksums.criDockerd;
   const releaseUrl = `${apiBaseUrl}/repos/Mirantis/cri-dockerd/releases/tags/${tag}`;
   const binaryTar = await downloadGitHubArtifact({
     inputs,
@@ -101,7 +155,8 @@ const installCriDockerd = async (inputs = {}) => {
       !isMac(asset.name) &&
       isArch(asset.name) &&
       isTgz(asset.name) &&
-      asset.name.indexOf('cri-dockerd') === 0
+      asset.name.indexOf('cri-dockerd') === 0,
+    expectedSha256: binarySha256[arch()]
   });
   // Binary
   const binaryDir = await tc.extractTar(binaryTar);
@@ -111,9 +166,9 @@ const installCriDockerd = async (inputs = {}) => {
   );
   logExecSync(`sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd`);
   // Service file
-  const sourceTar = await tc.downloadTool(
-    `${serverBaseUrl}/Mirantis/cri-dockerd/archive/refs/tags/${tag}.tar.gz`
-  );
+  const sourceTarUrl = `${serverBaseUrl}/Mirantis/cri-dockerd/archive/refs/tags/${tag}.tar.gz`;
+  const sourceTar = await tc.downloadTool(sourceTarUrl);
+  await verifySha256File(sourceTar, sourceSha256, 'cri-dockerd source archive');
   const sourceDir = await tc.extractTar(sourceTar);
   const sourceContent = firstDir(sourceDir);
   logExecSync(

--- a/src/download.js
+++ b/src/download.js
@@ -25,9 +25,12 @@ const firstDir = dir =>
     .map(f => f.name)[0];
 
 const assertSha256Hex = (hex, label) => {
-  if (typeof hex !== 'string' || !/^[0-9a-f]{64}$/i.test(hex)) {
+  // Lowercase only: crypto.digest('hex') and `sha256sum` both emit lowercase,
+  // so an uppercase value would assert OK and then silently fail the equality
+  // check downstream. Reject it here with an actionable message instead.
+  if (typeof hex !== 'string' || !/^[0-9a-f]{64}$/.test(hex)) {
     throw new Error(
-      `Invalid SHA256 digest for ${label}: expected 64 hex chars, got ${JSON.stringify(hex)}`
+      `Invalid SHA256 digest for ${label}: expected 64 lowercase hex chars, got ${JSON.stringify(hex)}`
     );
   }
 };
@@ -242,7 +245,8 @@ module.exports = {
   installCniPlugins,
   installCriCtl,
   installCriDockerd,
-  // Exposed for direct testing of the verification funnel:
+  /** @internal — exposed for testing the verification funnel. */
   downloadGitHubArtifact,
+  /** @internal — exposed for testing the verification funnel. */
   verifySha256File
 };

--- a/src/download.js
+++ b/src/download.js
@@ -24,7 +24,16 @@ const firstDir = dir =>
     .filter(f => f.isDirectory())
     .map(f => f.name)[0];
 
+const assertSha256Hex = (hex, label) => {
+  if (typeof hex !== 'string' || !/^[0-9a-f]{64}$/i.test(hex)) {
+    throw new Error(
+      `Invalid SHA256 digest for ${label}: expected 64 hex chars, got ${JSON.stringify(hex)}`
+    );
+  }
+};
+
 const verifySha256File = async (filePath, expectedHex, label) => {
+  assertSha256Hex(expectedHex, label);
   const actual = crypto
     .createHash('sha256')
     .update(await fs.promises.readFile(filePath))
@@ -50,7 +59,9 @@ const fetchCompanionSha256 = async ({asset, assets, inputs}) => {
     githubToken: inputs.githubToken,
     options: {responseType: 'text'}
   });
-  return String(response.data).trim().split(/\s+/)[0];
+  const parsed = String(response.data).trim().split(/\s+/)[0];
+  assertSha256Hex(parsed, `${asset.name}.sha256 response body`);
+  return parsed;
 };
 
 const downloadGitHubArtifact = async ({
@@ -60,9 +71,14 @@ const downloadGitHubArtifact = async ({
   verifyWithCompanionSha256 = false,
   expectedSha256
 }) => {
-  if (verifyWithCompanionSha256 === Boolean(expectedSha256)) {
+  if (verifyWithCompanionSha256 && expectedSha256) {
     throw new Error(
-      'downloadGitHubArtifact requires exactly one of `verifyWithCompanionSha256` or `expectedSha256`'
+      'downloadGitHubArtifact: both `verifyWithCompanionSha256` and `expectedSha256` were provided; pick exactly one.'
+    );
+  }
+  if (!verifyWithCompanionSha256 && !expectedSha256) {
+    throw new Error(
+      'downloadGitHubArtifact: neither `verifyWithCompanionSha256` nor `expectedSha256` was provided; one is required to verify the download.'
     );
   }
   const tagInfo = await gitHubRequest({
@@ -87,6 +103,16 @@ const downloadGitHubArtifact = async ({
   } else {
     await verifySha256File(downloadedFile, expectedSha256, asset.name);
   }
+  return downloadedFile;
+};
+
+// Paired download + verify for URLs that aren't release assets (e.g. GitHub
+// auto-generated source archives). Keeps verification inseparable from the
+// download so a future contributor can't add a bare tc.downloadTool call.
+const downloadVerifiedUrl = async ({url, expectedSha256, label}) => {
+  core.info(`Downloading from: ${url}`);
+  const downloadedFile = await tc.downloadTool(url);
+  await verifySha256File(downloadedFile, expectedSha256, label);
   return downloadedFile;
 };
 
@@ -145,6 +171,12 @@ const installCriDockerd = async (inputs = {}) => {
   // Pinned digests live in ./checksums.js because cri-dockerd does not publish
   // .sha256 companion assets for its .tgz or source archives.
   const {tag, binarySha256, sourceSha256} = checksums.criDockerd;
+  const expectedBinarySha256 = binarySha256[arch()];
+  if (!expectedBinarySha256) {
+    throw new Error(
+      `No pinned SHA256 for arch=${arch()} in checksums.criDockerd.binarySha256. Update src/checksums.js when adding a new arch.`
+    );
+  }
   const releaseUrl = `${apiBaseUrl}/repos/Mirantis/cri-dockerd/releases/tags/${tag}`;
   const binaryTar = await downloadGitHubArtifact({
     inputs,
@@ -156,7 +188,7 @@ const installCriDockerd = async (inputs = {}) => {
       isArch(asset.name) &&
       isTgz(asset.name) &&
       asset.name.indexOf('cri-dockerd') === 0,
-    expectedSha256: binarySha256[arch()]
+    expectedSha256: expectedBinarySha256
   });
   // Binary
   const binaryDir = await tc.extractTar(binaryTar);
@@ -166,9 +198,11 @@ const installCriDockerd = async (inputs = {}) => {
   );
   logExecSync(`sudo ln -sf /usr/local/bin/cri-dockerd /usr/bin/cri-dockerd`);
   // Service file
-  const sourceTarUrl = `${serverBaseUrl}/Mirantis/cri-dockerd/archive/refs/tags/${tag}.tar.gz`;
-  const sourceTar = await tc.downloadTool(sourceTarUrl);
-  await verifySha256File(sourceTar, sourceSha256, 'cri-dockerd source archive');
+  const sourceTar = await downloadVerifiedUrl({
+    url: `${serverBaseUrl}/Mirantis/cri-dockerd/archive/refs/tags/${tag}.tar.gz`,
+    expectedSha256: sourceSha256,
+    label: 'cri-dockerd source archive'
+  });
   const sourceDir = await tc.extractTar(sourceTar);
   const sourceContent = firstDir(sourceDir);
   logExecSync(
@@ -207,5 +241,8 @@ module.exports = {
   downloadMinikube,
   installCniPlugins,
   installCriCtl,
-  installCriDockerd
+  installCriDockerd,
+  // Exposed for direct testing of the verification funnel:
+  downloadGitHubArtifact,
+  verifySha256File
 };


### PR DESCRIPTION
## Summary

Closes #150.

Adds SHA256 integrity verification to every binary downloaded by `src/download.js`, so a tampered upstream asset (or a MitM'd download) is rejected before extraction. Motivated by an ASF infrastructure concern (`apache/infrastructure-actions`) flagging `tc.downloadTool(...)` calls without a companion checksum step.

## Approach

- **minikube, CNI plugins, crictl** — verified against the published `<asset>.sha256` companion asset that each upstream already ships. `downloadGitHubArtifact` looks the companion up by name, fetches it via `gitHubRequest` (forcing `responseType: 'text'`), parses the leading hex token, and aborts on mismatch.
- **cri-dockerd** — publishes no checksum companion of any kind for its `.tgz` or source archive. Expected digests are pinned in `src/checksums.js` (one entry per arch + one for the source archive). Bumping the cri-dockerd tag now requires bumping these digests too; the rotation procedure is documented in `AGENTS.md`.
- Verification is enforced inside `downloadGitHubArtifact`. The function requires exactly one of `verifyWithCompanionSha256` or `expectedSha256` and throws otherwise, so a new caller cannot silently skip the check.
- Mismatches throw with an actionable message naming the asset and both digests; missing companions throw with a message naming the asset.

## Test plan

- [x] \`npm test\` — 125/125 passing, including new tests for: success path (digest fetched), tampered binary (mismatch throws), missing \`.sha256\` companion (throws) — across minikube, CNI plugins, and crictl; tampered binary + tampered source for cri-dockerd.
- [x] \`npm run format-check\` — clean.
- [x] cri-dockerd pinned digests verified byte-for-byte against the live \`Mirantis/cri-dockerd@v0.3.24\` release assets.
- [x] E2E (\`runner.yml\`) — relies on the CI matrix once this PR runs.