### PR TITLE
chore(build): bump action runtime to Node.js 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI coding agents (GitHub Copilot, Claude Code, et
 
 ## Project Overview
 
-A GitHub Action that sets up a single-node Kubernetes cluster using Minikube in CI workflows. It downloads and installs Minikube with specified versions of Kubernetes, supporting multiple drivers (`none`, `docker`) and container runtimes (`docker`, `cri-o`, `containerd`). Built with Node.js 20 using GitHub Actions toolkit libraries.
+A GitHub Action that sets up a single-node Kubernetes cluster using Minikube in CI workflows. It downloads and installs Minikube with specified versions of Kubernetes, supporting multiple drivers (`none`, `docker`) and container runtimes (`docker`, `cri-o`, `containerd`). Built with Node.js 24 using GitHub Actions toolkit libraries.
 
 ## Working Effectively
 

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
   force:
     description: 'Set to true when --force was added to minikube start because the requested Kubernetes version is not in Minikube built-in supported list'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'src/index.js'

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-This project is a GitHub Action that sets up Minikube in CI workflows. It is built with Node.js 20 using ES Modules and the GitHub Actions toolkit libraries. Source files and production `node_modules/` are committed directly to the repository — there is no build step or bundler.
+This project is a GitHub Action that sets up Minikube in CI workflows. It is built with Node.js 24 using ES Modules and the GitHub Actions toolkit libraries. Source files and production `node_modules/` are committed directly to the repository — there is no build step or bundler.
 
 ## Execution Model
 
 ```
-GitHub Actions Runner (Node.js 20)
+GitHub Actions Runner (Node.js 24)
   │
-  ├── action.yml          ─── using: 'node20', main: 'src/index.js'
+  ├── action.yml          ─── using: 'node24', main: 'src/index.js'
   │
   ├── src/                ─── Source files (executed directly, no transpilation)
   │   ├── index.js        ─── Entry point, orchestrates the pipeline


### PR DESCRIPTION
## Summary

Migrates the action's declared runtime from `node20` to `node24` so the
action keeps working past GitHub's deprecation milestones:

- **June 2, 2026** — `node20` actions are forced to run on Node.js 24
- **September 16, 2026** — Node.js 20 is removed from runners entirely

Per the [GitHub Actions changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Changes

- `action.yml` — `runs.using` changed from `'node20'` to `'node24'`
- `docs/specs/architecture.md` — intro paragraph and runner diagram updated to Node.js 24
- `CLAUDE.md` / `AGENTS.md` — "Project Overview" updated to Node.js 24

No source code or dependency changes. All production dependencies
(`@actions/core`, `@actions/github`, `@actions/io`, `@actions/tool-cache`,
`axios`) are on recent versions already compatible with Node 24.

## Test plan

- [x] `npm test` — 10 suites, 129 tests pass
- [x] `npm run format-check` — pass
- [x] Repo-wide grep for `node20` / `Node.js 20` — only match is in a vendored `@actions/io` source comment, out of scope
- [x] Full E2E matrix in `.github/workflows/runner.yml` against Node 24 runtime

Closes #152