### PR TITLE
cache downloaded tools

### DIFF
--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -65,8 +65,14 @@ Each step is a separate module with a single responsibility:
 | `src/check-environment.js` | Validates Ubuntu version (18, 20, 22, 24) |
 | `src/load-inputs.js` | Loads action inputs via `@actions/core` |
 | `src/configure-environment.js` | Prepares system (apt packages, Docker, CNI plugins) |
-| `src/download.js` | Downloads binaries from GitHub releases |
+| `src/download.js` | Checks tool-cache, downloads+verifies+caches on miss |
 | `src/install.js` | Installs and starts Minikube |
+
+### Tool-Cache Lookup
+
+`src/download.js` checks `@actions/tool-cache`'s `tc.find(toolName, toolVersion, arch)` before downloading minikube, CNI plugins, crictl, or the cri-dockerd binary and source archive. On a hit, it returns the cached file and skips the network call and SHA256 verification (a runner-local cache entry was already verified when it was written). On a miss, it downloads, verifies, and calls `tc.cacheFile()` to populate the cache before returning. Extraction and install steps (`tc.extractTar`, `sudo install`, `systemctl`) always run afterward regardless of hit or miss, since CNI plugins/crictl/cri-dockerd install to system paths outside the tool-cache and those steps are idempotent.
+
+This only populates `RUNNER_TOOL_CACHE` for the lifetime of a single runner. A consuming workflow that wants the cache to persist across separate job runs restores/saves `RUNNER_TOOL_CACHE` with `actions/cache` around this action's step.
 
 ### Supporting Modules
 

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -101,6 +101,19 @@ describe('download module', () => {
     });
   });
 
+  describe('downloadVerifiedUrl tool-cache guard', () => {
+    test('throws when toolName, toolVersion, or cacheFileName are missing', async () => {
+      await expect(
+        download.downloadVerifiedUrl({
+          url: `${baseUrl}/some/archive.tar.gz`,
+          expectedSha256:
+            '0000000000000000000000000000000000000000000000000000000000000000',
+          label: 'some archive'
+        })
+      ).rejects.toThrow(/toolName.*toolVersion.*cacheFileName/);
+    });
+  });
+
   describe('downloadMinikube', () => {
     const amd64Binary = Buffer.from('fake-minikube-binary');
     const arm64Binary = Buffer.from('fake-minikube-binary-arm64');
@@ -1080,6 +1093,11 @@ describe('download module', () => {
         expect(tc.find('cri-dockerd', 'v0.3.24', arch())).not.toBe('');
       });
 
+      test('caches the downloaded source archive for reuse', async () => {
+        await download.installCriDockerd({});
+        expect(tc.find('cri-dockerd-source', 'v0.3.24', arch())).not.toBe('');
+      });
+
       describe('when the binary tarball is already cached', () => {
         beforeEach(async () => {
           const seedFile = path.join(tmpDir, 'seed-cri-dockerd.tgz');
@@ -1111,6 +1129,41 @@ describe('download module', () => {
                   r.pathname ===
                   '/Mirantis/cri-dockerd/archive/refs/tags/v0.3.24.tar.gz'
               )
+          ).toBe(true);
+        });
+      });
+
+      describe('when the source archive is already cached', () => {
+        beforeEach(async () => {
+          const seedFile = path.join(tmpDir, 'seed-cri-dockerd-source.tar.gz');
+          fs.writeFileSync(seedFile, sourceTarball);
+          await tc.cacheFile(
+            seedFile,
+            'cri-dockerd-source.tar.gz',
+            'cri-dockerd-source',
+            'v0.3.24',
+            arch()
+          );
+          await download.installCriDockerd({});
+        });
+
+        test('does not download the source archive', () => {
+          expect(
+            testServer
+              .getRequests()
+              .some(
+                r =>
+                  r.pathname ===
+                  '/Mirantis/cri-dockerd/archive/refs/tags/v0.3.24.tar.gz'
+              )
+          ).toBe(false);
+        });
+
+        test('still downloads the binary tarball', () => {
+          expect(
+            testServer
+              .getRequests()
+              .some(r => r.pathname === '/download/cri-dockerd-amd64.tgz')
           ).toBe(true);
         });
       });

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -351,6 +351,18 @@ describe('download module', () => {
         test('returns the cached file', () => {
           expect(fs.readFileSync(filePath)).toEqual(amd64Binary);
         });
+
+        test('returns a disposable copy outside the tool-cache directory', () => {
+          // install.js moves/renames the returned file in place (e.g. into
+          // the minikube home directory). Returning the live tool-cache path
+          // directly would let that mutate the persisted cache entry, and if
+          // the destination directory happens to resolve back to the same
+          // tool-cache path (as it does for minikube -- see the ENOENT
+          // self-rename this regression test guards against), the move fails.
+          expect(filePath.startsWith(process.env.RUNNER_TOOL_CACHE)).toBe(
+            false
+          );
+        });
       });
     });
   });

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -20,6 +20,7 @@ describe('download module', () => {
   let download;
   let tc;
   let exec;
+  let arch;
   let tmpDir;
   let originalArch;
 
@@ -37,6 +38,9 @@ describe('download module', () => {
     jest.resetModules();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'download-test-'));
     process.env.RUNNER_TEMP = tmpDir;
+    process.env.RUNNER_TOOL_CACHE = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'download-test-tool-cache-')
+    );
     process.env.GITHUB_API_URL = baseUrl;
     process.env.GITHUB_SERVER_URL = baseUrl;
     originalArch = process.arch;
@@ -44,6 +48,7 @@ describe('download module', () => {
     exec = require('../exec');
     download = require('../download');
     tc = require('@actions/tool-cache');
+    ({arch} = require('../arch'));
 
     testServer.clearRoutes();
     testServer.clearRequests();
@@ -51,7 +56,9 @@ describe('download module', () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, {recursive: true, force: true});
+    fs.rmSync(process.env.RUNNER_TOOL_CACHE, {recursive: true, force: true});
     delete process.env.RUNNER_TEMP;
+    delete process.env.RUNNER_TOOL_CACHE;
     delete process.env.GITHUB_API_URL;
     delete process.env.GITHUB_SERVER_URL;
     Object.defineProperty(process, 'arch', {value: originalArch});
@@ -79,6 +86,18 @@ describe('download module', () => {
           assetPredicate: () => true
         })
       ).rejects.toThrow(/neither .* was provided/);
+    });
+
+    test('throws when toolName, toolVersion, or cacheFileName are missing', async () => {
+      await expect(
+        download.downloadGitHubArtifact({
+          inputs: {},
+          releaseUrl: `${baseUrl}/some/release`,
+          assetPredicate: () => true,
+          expectedSha256:
+            '0000000000000000000000000000000000000000000000000000000000000000'
+        })
+      ).rejects.toThrow(/toolName.*toolVersion.*cacheFileName/);
     });
   });
 
@@ -287,6 +306,40 @@ describe('download module', () => {
         expect(error.message).toMatch(/Invalid SHA256 digest/);
       });
     });
+
+    describe('tool-cache', () => {
+      test('caches the downloaded binary for reuse', async () => {
+        await download.downloadMinikube({minikubeVersion: 'v1.33.7'});
+        expect(tc.find('minikube', 'v1.33.7', arch())).not.toBe('');
+      });
+
+      describe('when already cached', () => {
+        let filePath;
+
+        beforeEach(async () => {
+          const seedFile = path.join(tmpDir, 'seed-minikube');
+          fs.writeFileSync(seedFile, amd64Binary);
+          await tc.cacheFile(
+            seedFile,
+            'minikube',
+            'minikube',
+            'v1.33.7',
+            arch()
+          );
+          filePath = await download.downloadMinikube({
+            minikubeVersion: 'v1.33.7'
+          });
+        });
+
+        test('does not hit the network', () => {
+          expect(testServer.getRequests()).toHaveLength(0);
+        });
+
+        test('returns the cached file', () => {
+          expect(fs.readFileSync(filePath)).toEqual(amd64Binary);
+        });
+      });
+    });
   });
 
   describe('installCniPlugins', () => {
@@ -492,6 +545,32 @@ describe('download module', () => {
         );
       });
     });
+
+    describe('tool-cache', () => {
+      test('caches the downloaded tarball for reuse', async () => {
+        await download.installCniPlugins({});
+        expect(tc.find('cni-plugins', 'v1.9.0', arch())).not.toBe('');
+      });
+
+      describe('when already cached', () => {
+        beforeEach(async () => {
+          const seedFile = path.join(tmpDir, 'seed-cni-plugins.tgz');
+          fs.writeFileSync(seedFile, cniTarball);
+          await tc.cacheFile(
+            seedFile,
+            'cni-plugins.tgz',
+            'cni-plugins',
+            'v1.9.0',
+            arch()
+          );
+          await download.installCniPlugins({});
+        });
+
+        test('does not hit the network', () => {
+          expect(testServer.getRequests()).toHaveLength(0);
+        });
+      });
+    });
   });
 
   describe('installCriCtl', () => {
@@ -686,6 +765,32 @@ describe('download module', () => {
         );
       });
     });
+
+    describe('tool-cache', () => {
+      test('caches the downloaded tarball for reuse', async () => {
+        await download.installCriCtl({});
+        expect(tc.find('crictl', 'v1.35.0', arch())).not.toBe('');
+      });
+
+      describe('when already cached', () => {
+        beforeEach(async () => {
+          const seedFile = path.join(tmpDir, 'seed-crictl.tar.gz');
+          fs.writeFileSync(seedFile, crictlTarball);
+          await tc.cacheFile(
+            seedFile,
+            'crictl.tar.gz',
+            'crictl',
+            'v1.35.0',
+            arch()
+          );
+          await download.installCriCtl({});
+        });
+
+        test('does not hit the network', () => {
+          expect(testServer.getRequests()).toHaveLength(0);
+        });
+      });
+    });
   });
 
   describe('installCriDockerd', () => {
@@ -766,6 +871,7 @@ describe('download module', () => {
         '/etc/systemd/system/cri-docker.socket': SOCKET_FILE_CONTENT
       };
       const originalReadFileSync = fs.readFileSync.bind(fs);
+      const originalWriteFileSync = fs.writeFileSync.bind(fs);
       jest.spyOn(fs, 'readFileSync').mockImplementation((filePath, ...args) => {
         if (serviceFiles[filePath] !== undefined) {
           return serviceFiles[filePath];
@@ -779,9 +885,7 @@ describe('download module', () => {
             serviceFiles[filePath] = content;
             return;
           }
-          return jest
-            .requireActual('fs')
-            .writeFileSync(filePath, content, ...args);
+          return originalWriteFileSync(filePath, content, ...args);
         });
     });
 
@@ -967,6 +1071,48 @@ describe('download module', () => {
 
       test('throws naming the source archive', () => {
         expect(error.message).toMatch(/SHA256 mismatch.*cri-dockerd source/);
+      });
+    });
+
+    describe('tool-cache', () => {
+      test('caches the downloaded binary tarball for reuse', async () => {
+        await download.installCriDockerd({});
+        expect(tc.find('cri-dockerd', 'v0.3.24', arch())).not.toBe('');
+      });
+
+      describe('when the binary tarball is already cached', () => {
+        beforeEach(async () => {
+          const seedFile = path.join(tmpDir, 'seed-cri-dockerd.tgz');
+          fs.writeFileSync(seedFile, binaryTarball);
+          await tc.cacheFile(
+            seedFile,
+            'cri-dockerd.tgz',
+            'cri-dockerd',
+            'v0.3.24',
+            arch()
+          );
+          await download.installCriDockerd({});
+        });
+
+        test('does not download the binary tarball', () => {
+          expect(
+            testServer
+              .getRequests()
+              .some(r => r.pathname === '/download/cri-dockerd-amd64.tgz')
+          ).toBe(false);
+        });
+
+        test('still downloads the source archive', () => {
+          expect(
+            testServer
+              .getRequests()
+              .some(
+                r =>
+                  r.pathname ===
+                  '/Mirantis/cri-dockerd/archive/refs/tags/v0.3.24.tar.gz'
+              )
+          ).toBe(true);
+        });
       });
     });
   });

--- a/src/__tests__/download.test.js
+++ b/src/__tests__/download.test.js
@@ -582,6 +582,20 @@ describe('download module', () => {
         test('does not hit the network', () => {
           expect(testServer.getRequests()).toHaveLength(0);
         });
+
+        test('still extracts plugin binaries from the cached tarball', () => {
+          const installCmd = exec.logExecSync.mock.calls[0][0];
+          const extractedDir = installCmd.match(/sudo find (\S+)/)[1];
+          expect(fs.readdirSync(extractedDir)).toEqual(
+            expect.arrayContaining(['bridge', 'loopback'])
+          );
+        });
+
+        test('still installs to /opt/cni/bin', () => {
+          expect(exec.logExecSync).toHaveBeenCalledWith(
+            expect.stringMatching(/install -Dm 0755 .+\/opt\/cni\/bin/)
+          );
+        });
       });
     });
   });
@@ -801,6 +815,13 @@ describe('download module', () => {
 
         test('does not hit the network', () => {
           expect(testServer.getRequests()).toHaveLength(0);
+        });
+
+        test('still extracts the cached tarball to /usr/local/bin', () => {
+          expect(tc.extractTar).toHaveBeenCalledWith(
+            expect.any(String),
+            '/usr/local/bin'
+          );
         });
       });
     });
@@ -1131,6 +1152,21 @@ describe('download module', () => {
               )
           ).toBe(true);
         });
+
+        test('still installs the binary from the cached tarball', () => {
+          const installCall = exec.logExecSync.mock.calls.find(([cmd]) =>
+            cmd.includes('install -m 0755')
+          );
+          expect(installCall[0]).toMatch(
+            /\/cri-dockerd\/cri-dockerd \/usr\/local\/bin\//
+          );
+        });
+
+        test('still enables and starts the systemd service', () => {
+          expect(exec.logExecSync).toHaveBeenCalledWith(
+            'sudo systemctl enable --now cri-docker.socket'
+          );
+        });
       });
 
       describe('when the source archive is already cached', () => {
@@ -1165,6 +1201,17 @@ describe('download module', () => {
               .getRequests()
               .some(r => r.pathname === '/download/cri-dockerd-amd64.tgz')
           ).toBe(true);
+        });
+
+        test('still updates the service file from the cached source archive', () => {
+          const content =
+            serviceFiles['/etc/systemd/system/cri-docker.service'];
+          expect(content).toContain('--network-plugin=cni');
+        });
+
+        test('still replaces the socket path from the cached source archive', () => {
+          const content = serviceFiles['/etc/systemd/system/cri-docker.socket'];
+          expect(content).toBe('ListenStream=/var/run/cri-dockerd.sock');
         });
       });
     });

--- a/src/download.js
+++ b/src/download.js
@@ -4,6 +4,7 @@ const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
+const path = require('node:path');
 const {logExecSync} = require('./exec');
 const {gitHubRequest, apiBaseUrl, serverBaseUrl} = require('./github');
 const {arch} = require('./arch');
@@ -72,7 +73,10 @@ const downloadGitHubArtifact = async ({
   releaseUrl,
   assetPredicate,
   verifyWithCompanionSha256 = false,
-  expectedSha256
+  expectedSha256,
+  toolName,
+  toolVersion,
+  cacheFileName
 }) => {
   if (verifyWithCompanionSha256 && expectedSha256) {
     throw new Error(
@@ -83,6 +87,16 @@ const downloadGitHubArtifact = async ({
     throw new Error(
       'downloadGitHubArtifact: neither `verifyWithCompanionSha256` nor `expectedSha256` was provided; one is required to verify the download.'
     );
+  }
+  if (!toolName || !toolVersion || !cacheFileName) {
+    throw new Error(
+      'downloadGitHubArtifact: `toolName`, `toolVersion`, and `cacheFileName` are all required to check/populate the tool-cache.'
+    );
+  }
+  const cachedDir = tc.find(toolName, toolVersion, arch());
+  if (cachedDir) {
+    core.info(`Using cached ${toolName} ${toolVersion} (${arch()})`);
+    return path.join(cachedDir, cacheFileName);
   }
   const tagInfo = await gitHubRequest({
     url: releaseUrl,
@@ -106,6 +120,13 @@ const downloadGitHubArtifact = async ({
   } else {
     await verifySha256File(downloadedFile, expectedSha256, asset.name);
   }
+  await tc.cacheFile(
+    downloadedFile,
+    cacheFileName,
+    toolName,
+    toolVersion,
+    arch()
+  );
   return downloadedFile;
 };
 
@@ -126,7 +147,10 @@ const downloadMinikube = async (inputs = {}) => {
     releaseUrl: `${apiBaseUrl}/repos/kubernetes/minikube/releases/tags/${inputs.minikubeVersion}`,
     assetPredicate: asset =>
       isLinux(asset.name) && isArch(asset.name) && !isSignature(asset.name),
-    verifyWithCompanionSha256: true
+    verifyWithCompanionSha256: true,
+    toolName: 'minikube',
+    toolVersion: inputs.minikubeVersion,
+    cacheFileName: 'minikube'
   });
 };
 
@@ -144,7 +168,10 @@ const installCniPlugins = async (inputs = {}) => {
       isArch(asset.name) &&
       !isSignature(asset.name) &&
       asset.name.indexOf('cni-plugins') === 0,
-    verifyWithCompanionSha256: true
+    verifyWithCompanionSha256: true,
+    toolName: 'cni-plugins',
+    toolVersion: tag,
+    cacheFileName: 'cni-plugins.tgz'
   });
   const extractedTarDir = await tc.extractTar(tar);
   const cniBinDirPath = '/opt/cni/bin';
@@ -164,7 +191,10 @@ const installCriCtl = async (inputs = {}) => {
       isArch(asset.name) &&
       !isSignature(asset.name) &&
       asset.name.indexOf('crictl') === 0,
-    verifyWithCompanionSha256: true
+    verifyWithCompanionSha256: true,
+    toolName: 'crictl',
+    toolVersion: tag,
+    cacheFileName: 'crictl.tar.gz'
   });
   await tc.extractTar(tar, '/usr/local/bin');
 };
@@ -191,7 +221,10 @@ const installCriDockerd = async (inputs = {}) => {
       isArch(asset.name) &&
       isTgz(asset.name) &&
       asset.name.indexOf('cri-dockerd') === 0,
-    expectedSha256: expectedBinarySha256
+    expectedSha256: expectedBinarySha256,
+    toolName: 'cri-dockerd',
+    toolVersion: tag,
+    cacheFileName: 'cri-dockerd.tgz'
   });
   // Binary
   const binaryDir = await tc.extractTar(binaryTar);

--- a/src/download.js
+++ b/src/download.js
@@ -133,10 +133,34 @@ const downloadGitHubArtifact = async ({
 // Paired download + verify for URLs that aren't release assets (e.g. GitHub
 // auto-generated source archives). Keeps verification inseparable from the
 // download so a future contributor can't add a bare tc.downloadTool call.
-const downloadVerifiedUrl = async ({url, expectedSha256, label}) => {
+const downloadVerifiedUrl = async ({
+  url,
+  expectedSha256,
+  label,
+  toolName,
+  toolVersion,
+  cacheFileName
+}) => {
+  if (!toolName || !toolVersion || !cacheFileName) {
+    throw new Error(
+      'downloadVerifiedUrl: `toolName`, `toolVersion`, and `cacheFileName` are all required to check/populate the tool-cache.'
+    );
+  }
+  const cachedDir = tc.find(toolName, toolVersion, arch());
+  if (cachedDir) {
+    core.info(`Using cached ${toolName} ${toolVersion} (${arch()})`);
+    return path.join(cachedDir, cacheFileName);
+  }
   core.info(`Downloading from: ${url}`);
   const downloadedFile = await tc.downloadTool(url);
   await verifySha256File(downloadedFile, expectedSha256, label);
+  await tc.cacheFile(
+    downloadedFile,
+    cacheFileName,
+    toolName,
+    toolVersion,
+    arch()
+  );
   return downloadedFile;
 };
 
@@ -237,7 +261,10 @@ const installCriDockerd = async (inputs = {}) => {
   const sourceTar = await downloadVerifiedUrl({
     url: `${serverBaseUrl}/Mirantis/cri-dockerd/archive/refs/tags/${tag}.tar.gz`,
     expectedSha256: sourceSha256,
-    label: 'cri-dockerd source archive'
+    label: 'cri-dockerd source archive',
+    toolName: 'cri-dockerd-source',
+    toolVersion: tag,
+    cacheFileName: 'cri-dockerd-source.tar.gz'
   });
   const sourceDir = await tc.extractTar(sourceTar);
   const sourceContent = firstDir(sourceDir);
@@ -280,6 +307,8 @@ module.exports = {
   installCriDockerd,
   /** @internal — exposed for testing the verification funnel. */
   downloadGitHubArtifact,
+  /** @internal — exposed for testing the verification funnel. */
+  downloadVerifiedUrl,
   /** @internal — exposed for testing the verification funnel. */
   verifySha256File
 };

--- a/src/download.js
+++ b/src/download.js
@@ -2,6 +2,7 @@
 
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
+const io = require('@actions/io');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -68,6 +69,23 @@ const fetchCompanionSha256 = async ({asset, assets, inputs}) => {
   return parsed;
 };
 
+// Callers mutate/relocate the returned file in place (e.g. install.js moves
+// the minikube binary via io.mv). Returning the live tool-cache path directly
+// would let that mutation touch the persisted cache entry -- and if the
+// destination happens to land back inside the same tool-cache directory
+// (as it does for minikube), io.mv's remove-then-rename turns into a
+// self-inflicted ENOENT. Copy to a disposable temp file instead so a cache
+// hit behaves exactly like a fresh download from the caller's perspective.
+const copyFromToolCache = async (cachedDir, cacheFileName) => {
+  const cachedFile = path.join(cachedDir, cacheFileName);
+  const tempFile = path.join(
+    process.env.RUNNER_TEMP,
+    `${crypto.randomUUID()}-${cacheFileName}`
+  );
+  await io.cp(cachedFile, tempFile);
+  return tempFile;
+};
+
 const downloadGitHubArtifact = async ({
   inputs,
   releaseUrl,
@@ -96,7 +114,7 @@ const downloadGitHubArtifact = async ({
   const cachedDir = tc.find(toolName, toolVersion, arch());
   if (cachedDir) {
     core.info(`Using cached ${toolName} ${toolVersion} (${arch()})`);
-    return path.join(cachedDir, cacheFileName);
+    return copyFromToolCache(cachedDir, cacheFileName);
   }
   const tagInfo = await gitHubRequest({
     url: releaseUrl,
@@ -149,7 +167,7 @@ const downloadVerifiedUrl = async ({
   const cachedDir = tc.find(toolName, toolVersion, arch());
   if (cachedDir) {
     core.info(`Using cached ${toolName} ${toolVersion} (${arch()})`);
-    return path.join(cachedDir, cacheFileName);
+    return copyFromToolCache(cachedDir, cacheFileName);
   }
   core.info(`Downloading from: ${url}`);
   const downloadedFile = await tc.downloadTool(url);


### PR DESCRIPTION
Closes #154

## Problem

This action downloads minikube, CNI plugins, crictl, and cri-dockerd from
GitHub release APIs on every run. A transient GitHub API failure fails the
whole job, and nothing lets a workflow reuse a binary a prior run already
downloaded.

## What changed

`downloadGitHubArtifact` and `downloadVerifiedUrl` in `src/download.js` now
check `tc.find()` before downloading. A cache hit returns the cached file and
skips both the network call and SHA256 re-verification (the entry was already
verified when it was written). A miss downloads, verifies, and calls
`tc.cacheFile()` to populate `RUNNER_TOOL_CACHE` before returning. Extraction
and install steps (`tc.extractTar`, `sudo install`, `systemctl`) always run
afterward regardless of hit or miss, since CNI plugins, crictl, and
cri-dockerd install to system paths outside the tool-cache.

A workflow that wants the cache to persist across separate job runs can
restore/save `RUNNER_TOOL_CACHE` with `actions/cache` around this action's
step.

## Kludge - we always copy from the cache to a tempdir to avoid install.js trying to move the file to the same path

On a cache hit, the funnel initially returned the live path inside
`RUNNER_TOOL_CACHE`. `install.js` renames the downloaded minikube binary via
`io.mv` to normalize its filename, and since the cached path was already
named `minikube`, the rename source and destination were identical --
`io.mv` deletes the destination before renaming, turning this into a
self-inflicted `ENOENT`:

Error: ENOENT: no such file or directory, rename
'/opt/hostedtoolcache/minikube/1.38.1/arm64/minikube' ->
'/opt/hostedtoolcache/minikube/1.38.1/arm64/minikube'

Both cache-hit branches now copy the cached artifact to a disposable
`RUNNER_TEMP` file before returning, matching what a cache miss already
returns.
